### PR TITLE
Add Support For Integer-Backed Enums

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [{
         "label": "build",
         "command": "zig",
-        "args": ["build"],
+        "args": ["build", "-Dllvm"],
         "type": "shell"
     }]
 }

--- a/assets/cprint/main.c
+++ b/assets/cprint/main.c
@@ -6,6 +6,12 @@ typedef struct TestStruct {
     int B;
 } TestStruct;
 
+typedef enum TestEnum {
+    ONE,
+    TWO,
+    THREE,
+} TestEnum ;
+
 int main() {
     char      a = 1;
     short     b = 2;
@@ -42,6 +48,10 @@ int main() {
     heap_str[2] = 's';
     heap_str[3] = '\0';
 
+    enum TestEnum enum_one = ONE;
+    enum TestEnum enum_two = TWO;
+    enum TestEnum enum_three = THREE;
+
     printf("A: %d\n", a);
     printf("B: %d\n", b);
     printf("C: %d\n", c);
@@ -67,4 +77,8 @@ int main() {
     printf("ARR: %p\n", arr);
     printf("STR: %s\n", basic_str);
     printf("HEAP STR: %s\n", heap_str);
+
+    printf("ENUM ONE: %d\n", enum_one);
+    printf("ENUM TWO: %d\n", enum_two);
+    printf("ENUM THREE: %d\n", enum_three);
 }

--- a/assets/zigprint/main.zig
+++ b/assets/zigprint/main.zig
@@ -24,6 +24,14 @@ const ExternStruct = extern struct {
     fn dontOptimizeMe(_: *@This()) void {}
 };
 
+const MyEnum = enum(u8) {
+    first,
+    second,
+    final = 100,
+
+    fn dontOptimizeMe(_: *@This()) void {}
+};
+
 pub fn main() !void {
     const a: i2 = 1;
     const b: u2 = 2;
@@ -86,6 +94,10 @@ pub fn main() !void {
     const at = try std.heap.page_allocator.alloc(u32, as.len);
     @memcpy(at, &as);
 
+    const au = MyEnum.first;
+    const av = MyEnum.second;
+    const aw = MyEnum.final;
+
     print("{}\n", .{a});
     print("{}\n", .{b});
     print("{}\n", .{c}); // sim:zigprint stops here
@@ -139,4 +151,8 @@ pub fn main() !void {
 
     print("{d}\n", .{as});
     print("{d}\n", .{at});
+
+    print("{s}\n", .{@tagName(au)});
+    print("{s}\n", .{@tagName(av)});
+    print("{s}\n", .{@tagName(aw)});
 }

--- a/assets/zigprint/main.zig
+++ b/assets/zigprint/main.zig
@@ -24,7 +24,9 @@ const ExternStruct = extern struct {
     fn dontOptimizeMe(_: *@This()) void {}
 };
 
-const MyEnum = enum(u8) {
+const MyEnum = enum(i8) {
+    negative = -1,
+    zero,
     first,
     second,
     final = 100,
@@ -94,7 +96,7 @@ pub fn main() !void {
     const at = try std.heap.page_allocator.alloc(u32, as.len);
     @memcpy(at, &as);
 
-    const au = MyEnum.first;
+    const au = MyEnum.negative;
     const av = MyEnum.second;
     const aw = MyEnum.final;
 

--- a/src/linux/dwarf.zig
+++ b/src/linux/dwarf.zig
@@ -863,7 +863,9 @@ fn mapDWARFToTarget(cu: *info.CompileUnit, dies: []const info.DIE) ParseError!Co
 
                         try values.append(.{
                             .name = try parseAndCacheString(&value_opts, .DW_AT_name, str_cache),
-                            .value = try requiredAttribute(&value_opts, i128, .DW_AT_const_value),
+                            .value = types.EnumInstanceValue.from(
+                                try requiredAttribute(&value_opts, i128, .DW_AT_const_value),
+                            ),
                         });
 
                         assert(value_ndx <= max_values - 1);

--- a/src/test/simulator.zig
+++ b/src/test/simulator.zig
@@ -650,7 +650,7 @@ test "sim:zigprint" {
         .send_after_ticks = 1,
         .req = (proto.UpdateBreakpointRequest{ .loc = .{ .source = .{
             .file_hash = zigprint_main_zig_hash,
-            .line = types.SourceLine.from(104),
+            .line = types.SourceLine.from(105),
         }}}).req(),
     })
 
@@ -824,16 +824,43 @@ test "sim:zigprint" {
                                     return false;
                                 }
 
-                                if (!check(second.data != null, "enum data must not be null") or
-                                    !checkeq(i128, 100, second.data.?, "unexpected enum value \"aw\"")) {
-                                    return false;
+                                if (!check(second.data != null, "enum data must not be null")) return false;
+                                if (paused.strings.get(second.data.?)) |enum_data| {
+                                    const enum_val = mem.readVarInt(i128, enum_data, .little);
+                                    if (!checkeq(i128, 100, enum_val, "unexpected enum value \"aw\"")) return false;
                                 }
 
                                 if (!check(second.name != null, "enum name must not be null") or
-                                    !checkstr(paused.strings, "final", second.name.?, "unexpected name for enum \"av\"")) {
+                                    !checkstr(paused.strings, "final", second.name.?, "unexpected name for enum \"aw\"")) {
                                     return false;
                                 }
                             }
+
+                            // {
+                            //     // check rendering a negative enum value
+                            //     const au = paused.getLocalByName("au") orelse return falseWithErr("unable to get local \"au\"", .{});
+                            //     const first = au.fields[0];
+                            //     const second = au.fields[1];
+                            //     if (first.encoding != .@"enum") {
+                            //         log.errf("variable \"au\" encoding was not an enum, got {s}", .{@tagName(first.encoding)});
+                            //         return false;
+                            //     }
+                            //     if (second.encoding != .primitive) {
+                            //         log.errf("variable \"au\" value encoding was not primitive, got {s}", .{@tagName(second.encoding)});
+                            //         return false;
+                            //     }
+
+                            //     if (!check(second.data != null, "enum data must not be null")) return false;
+                            //     if (paused.strings.get(second.data.?)) |enum_data| {
+                            //         const enum_val = mem.readVarInt(i128, enum_data, .little);
+                            //         if (!checkeq(i128, -1, enum_val, "unexpected enum value \"au\"")) return false;
+                            //     }
+
+                            //     if (!check(second.name != null, "enum name must not be null") or
+                            //         !checkstr(paused.strings, "final", second.name.?, "unexpected name for enum \"av\"")) {
+                            //         return false;
+                            //     }
+                            // }
 
                             return true;
                         }

--- a/src/test/simulator.zig
+++ b/src/test/simulator.zig
@@ -810,6 +810,26 @@ test "sim:zigprint" {
                                 }
                             }
 
+                            {
+                                // check rendering an enum value
+                                const aw = paused.getLocalByName("aw") orelse return falseWithErr("unable to get local \"aw\"", .{});
+                                const field = aw.fields[0];
+                                if (field.encoding != .@"enum") {
+                                    log.errf("variable \"aw\" encoding was not an enum, got {s}", .{@tagName(field.encoding)});
+                                    return false;
+                                }
+
+                                const enm = field.encoding.@"enum";
+                                if (!checkeq(i128, 100, enm.value.int(), "unexpected enum value \"aw\"")) {
+                                    return false;
+                                }
+
+                                if (!check(enm.name != null, "enum name must not be null") or
+                                    !checkstr(paused.strings, "final", enm.name.?, "unexpected name for enum \"av\"")) {
+                                    return false;
+                                }
+                            }
+
                             return true;
                         }
 

--- a/src/test/simulator.zig
+++ b/src/test/simulator.zig
@@ -836,31 +836,31 @@ test "sim:zigprint" {
                                 }
                             }
 
-                            // {
-                            //     // check rendering a negative enum value
-                            //     const au = paused.getLocalByName("au") orelse return falseWithErr("unable to get local \"au\"", .{});
-                            //     const first = au.fields[0];
-                            //     const second = au.fields[1];
-                            //     if (first.encoding != .@"enum") {
-                            //         log.errf("variable \"au\" encoding was not an enum, got {s}", .{@tagName(first.encoding)});
-                            //         return false;
-                            //     }
-                            //     if (second.encoding != .primitive) {
-                            //         log.errf("variable \"au\" value encoding was not primitive, got {s}", .{@tagName(second.encoding)});
-                            //         return false;
-                            //     }
+                            {
+                                // check rendering a negative enum value
+                                const au = paused.getLocalByName("au") orelse return falseWithErr("unable to get local \"au\"", .{});
+                                const first = au.fields[0];
+                                const second = au.fields[1];
+                                if (first.encoding != .@"enum") {
+                                    log.errf("variable \"au\" encoding was not an enum, got {s}", .{@tagName(first.encoding)});
+                                    return false;
+                                }
+                                if (second.encoding != .primitive) {
+                                    log.errf("variable \"au\" value encoding was not primitive, got {s}", .{@tagName(second.encoding)});
+                                    return false;
+                                }
 
-                            //     if (!check(second.data != null, "enum data must not be null")) return false;
-                            //     if (paused.strings.get(second.data.?)) |enum_data| {
-                            //         const enum_val = mem.readVarInt(i128, enum_data, .little);
-                            //         if (!checkeq(i128, -1, enum_val, "unexpected enum value \"au\"")) return false;
-                            //     }
+                                if (!check(second.data != null, "enum data must not be null")) return false;
+                                if (paused.strings.get(second.data.?)) |enum_data| {
+                                    const enum_val = mem.readVarInt(i8, enum_data, .little);
+                                    if (!checkeq(i128, -1, enum_val, "unexpected enum value \"au\"")) return false;
+                                }
 
-                            //     if (!check(second.name != null, "enum name must not be null") or
-                            //         !checkstr(paused.strings, "final", second.name.?, "unexpected name for enum \"av\"")) {
-                            //         return false;
-                            //     }
-                            // }
+                                if (!check(second.name != null, "enum name must not be null") or
+                                    !checkstr(paused.strings, "negative", second.name.?, "unexpected name for enum \"av\"")) {
+                                    return false;
+                                }
+                            }
 
                             return true;
                         }

--- a/src/test/simulator.zig
+++ b/src/test/simulator.zig
@@ -618,7 +618,7 @@ test "sim:zigprint" {
     const exe_path = "assets/zigprint/out";
     const zigprint_main_zig_hash = try fileHash(t.allocator, "assets/zigprint/main.zig");
 
-    const expected_output_len = 442;
+    const expected_output_len = 461;
 
     // zig fmt: off
     sim.lock()
@@ -650,7 +650,7 @@ test "sim:zigprint" {
         .send_after_ticks = 1,
         .req = (proto.UpdateBreakpointRequest{ .loc = .{ .source = .{
             .file_hash = zigprint_main_zig_hash,
-            .line = types.SourceLine.from(91),
+            .line = types.SourceLine.from(103),
         }}}).req(),
     })
 
@@ -693,7 +693,7 @@ test "sim:zigprint" {
                         if (s.state.subordinate_output.len == 0) return null;
 
                         // spot check a few fields
-                        const num_locals = 46;
+                        const num_locals = 49;
                         if (checkeq(usize, 4, s.state.subordinate_output.len, "unexpected program output len") and
                             checkeq(usize, num_locals, paused.locals.len, "unexpected number of local variables") and
                             checkeq(usize, num_locals, paused.locals.len, "unexpected number of local variable expression results") and

--- a/src/types.zig
+++ b/src/types.zig
@@ -771,7 +771,7 @@ pub const EnumValue = struct {
     name: strings.Hash,
 
     /// The value of this entry in the enum
-    value: i128,
+    value: EnumInstanceValue,
 };
 
 /// Represents an array or a slice
@@ -1182,9 +1182,11 @@ pub const StructRenderer = struct {
 
 /// Renders enum values, possibly a tagged union
 pub const EnumRenderer = struct {
-    /// A pointer to the type of data contained in this enum instance
-    val: ExpressionFieldNdx,
+    /// The integer value of instance of the enum
+    value: EnumInstanceValue,
 
-    /// The name of the member of the enum to display for convenience (if known)
+    /// The user-friendly name of the enum value to display (if known)
     name: ?strings.Hash,
 };
+
+pub const EnumInstanceValue = NumericType(i128);

--- a/src/types.zig
+++ b/src/types.zig
@@ -774,6 +774,8 @@ pub const EnumValue = struct {
     value: EnumInstanceValue,
 };
 
+pub const EnumInstanceValue = NumericType(i128);
+
 /// Represents an array or a slice
 pub const ArrayType = struct {
     /// An index that indicates the type of each element contained in this array
@@ -1182,11 +1184,11 @@ pub const StructRenderer = struct {
 
 /// Renders enum values, possibly a tagged union
 pub const EnumRenderer = struct {
-    /// The integer value of instance of the enum
-    value: EnumInstanceValue,
+    /// A pointer to the type of data contained in this enum instance. We need to use an
+    /// `ExpressionFieldNdx` because this enum may point at any arbitrary data (i.e. in
+    /// the case of a tagged union in zig).
+    value: ExpressionFieldNdx,
 
     /// The user-friendly name of the enum value to display (if known)
     name: ?strings.Hash,
 };
-
-pub const EnumInstanceValue = NumericType(i128);


### PR DESCRIPTION
Adds support for basic integer-backed enums in C and Zig (i.e. tagged enums are not yet supported).

Adds a `sim:zigprint` simulator test case that spot checks that these values have been rendered correctly.

The watch window shows an example of a zig enum backed by a u8:

![image](https://github.com/user-attachments/assets/500a6d4d-b412-464a-9a3d-b3a563d085c7)
