### PR TITLE
Add Support for C-Style Typedefs

### DIFF
--- a/assets/cprint/main.c
+++ b/assets/cprint/main.c
@@ -48,9 +48,9 @@ int main() {
     heap_str[2] = 's';
     heap_str[3] = '\0';
 
-    enum TestEnum enum_one = ONE;
-    enum TestEnum enum_two = TWO;
-    enum TestEnum enum_three = THREE;
+    TestEnum enum_one = ONE;
+    TestEnum enum_two = TWO;
+    TestEnum enum_three = THREE;
 
     printf("A: %d\n", a);
     printf("B: %d\n", b);

--- a/assets/cprint/main.c
+++ b/assets/cprint/main.c
@@ -40,7 +40,7 @@ int main() {
     arr[1] = 4.56;
     arr[13] = 7.89;
 
-    char *basic_str = "Hello, world!\n";
+    char *basic_str = "Hello, world!";
 
     char *heap_str = (char*)malloc(4 * sizeof(char));
     heap_str[0] = 'y';
@@ -48,12 +48,13 @@ int main() {
     heap_str[2] = 's';
     heap_str[3] = '\0';
 
+    // test with and without the `enum` prefix
     TestEnum enum_one = ONE;
-    TestEnum enum_two = TWO;
+    enum TestEnum enum_two = TWO;
     TestEnum enum_three = THREE;
 
     printf("A: %d\n", a);
-    printf("B: %d\n", b);
+    printf("B: %d\n", b); // sim:cprint stops here
     printf("C: %d\n", c);
     printf("D: %ld\n", d);
     printf("E: %lld\n", e);

--- a/src/debugger/debugger.zig
+++ b/src/debugger/debugger.zig
@@ -2370,6 +2370,21 @@ fn DebuggerType(comptime AdapterType: anytype) type {
                     });
                 },
 
+                .typedef => |typedef| {
+                    if (typedef.data_type == null) {
+                        log.warnf("unable to calculate value for expresion \"{s}\": typedef type is opaque", .{
+                            params.expression,
+                        });
+                        return;
+                    }
+
+                    // recurse using the base data type
+                    var recursive_params = params;
+                    recursive_params.variable.data_type = typedef.data_type.?;
+
+                    try self.renderVariableValue(fields, recursive_params);
+                },
+
                 .@"struct" => |strct| {
                     try fields.append(params.scratch, .{
                         .data = null,


### PR DESCRIPTION
We now recursively follow typedefs to their root to ensure we can render the case where the user has done a typedef, or they have not.

This also adds a cprint simulator test, which is something I've been meaning to do for a while. It tests the typedef condition as well as rendering some other basic variables.

Note that the `(unknowns)` in the screenshot below are high on my priority list of things to take care of, but you can see that the enums are correctly rendered in the watch window:

![image](https://github.com/user-attachments/assets/3d79028c-9ab4-42dc-8b81-3abaf9a8dd6f)
