### PR TITLE
Render Array Variables

### DIFF
--- a/assets/cprint/main.c
+++ b/assets/cprint/main.c
@@ -48,6 +48,12 @@ int main() {
     heap_str[2] = 's';
     heap_str[3] = '\0';
 
+    char* strings[4];
+    strings[0] = "this";
+    strings[1] = "is";
+    strings[2] = "a";
+    strings[3] = "test";
+
     // test with and without the `enum` prefix
     TestEnum enum_one = ONE;
     enum TestEnum enum_two = TWO;
@@ -78,6 +84,10 @@ int main() {
     printf("ARR: %p\n", arr);
     printf("STR: %s\n", basic_str);
     printf("HEAP STR: %s\n", heap_str);
+    printf("STRINGS[0]: %s\n", strings[0]);
+    printf("STRINGS[1]: %s\n", strings[1]);
+    printf("STRINGS[2]: %s\n", strings[2]);
+    printf("STRINGS[3]: %s\n", strings[3]);
 
     printf("ENUM ONE: %d\n", enum_one);
     printf("ENUM TWO: %d\n", enum_two);

--- a/src/linux/Adapter.zig
+++ b/src/linux/Adapter.zig
@@ -876,7 +876,7 @@ pub const GetVariableValueArgs = struct {
     pid: types.PID,
     registers: *const arch.Registers,
     load_addr: types.Address,
-    variable_size: u32,
+    variable_size: u64,
     frame_base: types.Address,
     frame_base_platform_data: []const u8,
     platform_data: []const u8,

--- a/src/linux/Expression.zig
+++ b/src/linux/Expression.zig
@@ -49,7 +49,7 @@ pub const EvaluationError = error{
 alloc: Allocator,
 pid: types.PID,
 location_expression: String,
-variable_size: u32,
+variable_size: u64,
 frame_base: types.Address,
 frame_base_location_expr: String,
 load_addr: types.Address,

--- a/src/linux/dwarf.zig
+++ b/src/linux/dwarf.zig
@@ -1026,8 +1026,12 @@ fn mapDWARFToTarget(cu: *info.CompileUnit, dies: []const info.DIE) ParseError!Co
 
             const arr_ptr = &data_types.items[arr_type.variable_ndx.int()];
             arr_ptr.*.form.array.element_type = data_type_ndx;
-            arr_ptr.*.size_bytes = data_type.size_bytes;
             arr_ptr.*.name = try str_cache.add(type_name);
+
+            arr_ptr.*.size_bytes = 0;
+            if (arr_ptr.form.array.len) |len| {
+                arr_ptr.*.size_bytes = data_type.size_bytes * len;
+            }
         }
     }
 

--- a/src/test/simulator.zig
+++ b/src/test/simulator.zig
@@ -2272,6 +2272,42 @@ test "sim:cprint" {
                         }
                     }
 
+                    {
+                        // test rendering a stack-allocated array
+                        const arr = paused.getLocalByName("arr") orelse return falseWithErr("unable to get local \"arr\"", .{});
+                        if (!checkeq(usize, 15, arr.fields.len, "unexpected number of fields on struct \"arr\"")) return false;
+
+                        {
+                            // check the zero'th array element
+                            const data_hash = arr.fields[1].data orelse return falseWithErr("first member not set on variable \"arr\"", .{});
+                            const val = mem.readVarInt(u32, paused.getString(data_hash), .little);
+                            const val_float: f32 = @bitCast(val);
+                            if (!checkeq(f32, 1.23, val_float, "unexpected render value for zero'th element in \"arr\"")) {
+                                return false;
+                            }
+                        }
+
+                        {
+                            // check the third array element
+                            const data_hash = arr.fields[3].data orelse return falseWithErr("third member not set on variable \"arr\"", .{});
+                            const val = mem.readVarInt(u32, paused.getString(data_hash), .little);
+                            const val_float: f32 = @bitCast(val);
+                            if (!checkeq(f32, 0, val_float, "unexpected render value for third element in \"arr\"")) {
+                                return false;
+                            }
+                        }
+
+                        {
+                            // check the final array element
+                            const data_hash = arr.fields[14].data orelse return falseWithErr("final member not set on variable \"arr\"", .{});
+                            const val = mem.readVarInt(u32, paused.getString(data_hash), .little);
+                            const val_float: f32 = @bitCast(val);
+                            if (!checkeq(f32, 7.89, val_float, "unexpected render value for final element in \"arr\"")) {
+                                return false;
+                            }
+                        }
+                    }
+
                     return true;
                 } else |err| {
                     log.errf("unable to get state snapshot: {!}", .{err});

--- a/src/test/simulator.zig
+++ b/src/test/simulator.zig
@@ -2127,7 +2127,7 @@ test "sim:cprint" {
     const exe_path = "assets/cprint/out";
     const cprint_main_c_hash = try fileHash(t.allocator, "assets/cprint/main.c");
 
-    const expected_output_len = 245;
+    const expected_output_len = 308;
 
     // zig fmt: off
     sim.lock()
@@ -2159,7 +2159,7 @@ test "sim:cprint" {
         .send_after_ticks = 1,
         .req = (proto.UpdateBreakpointRequest{ .loc = .{ .source = .{
             .file_hash = cprint_main_c_hash,
-            .line = types.SourceLine.from(57),
+            .line = types.SourceLine.from(63),
         }}}).req(),
     })
 
@@ -2195,7 +2195,7 @@ test "sim:cprint" {
                         return false;
 
                     // spot check a few fields
-                    const num_locals = 21;
+                    const num_locals = 22;
                     if (!checkeq(usize, num_locals, paused.locals.len, "unexpected number of local variables") or
                         !checkeq(usize, num_locals, paused.locals.len, "unexpected number of local variable expression results") or
                         !checkeq(String, "a", paused.strings.get(paused.locals[0].expression) orelse "", "first local expression was incorrect") or

--- a/src/types.zig
+++ b/src/types.zig
@@ -674,7 +674,7 @@ pub const Function = struct {
 /// A type declaration within a CompileUnit
 pub const DataType = struct {
     /// The number of bytes required to store a variable of this type
-    size_bytes: u32,
+    size_bytes: u64,
 
     /// The hash of the name of the data type
     name: strings.Hash,


### PR DESCRIPTION
Adds the ability to render array variables of a known length.

See the `arr` and `strings` variables below for example.

![image](https://github.com/user-attachments/assets/5fa5e361-36fe-4c64-b562-7fc2c21fe71c)