### PR TITLE
Gracefully Handle Circular Pointers

### DIFF
--- a/assets/cprint/main.c
+++ b/assets/cprint/main.c
@@ -12,6 +12,12 @@ typedef enum TestEnum {
     THREE,
 } TestEnum ;
 
+typedef struct CircularPointer CircularPointer;
+struct CircularPointer {
+    int value;
+    CircularPointer* ptr;
+};
+
 int main() {
     char      a = 1;
     short     b = 2;
@@ -59,6 +65,14 @@ int main() {
     enum TestEnum enum_two = TWO;
     TestEnum enum_three = THREE;
 
+    // Create a circular pointer chain
+    CircularPointer* circular_a = (CircularPointer*)malloc(sizeof(CircularPointer));
+    circular_a->value = 17;
+    CircularPointer* circular_b = (CircularPointer*)malloc(sizeof(CircularPointer));
+    circular_b->value = 18;
+    circular_b->ptr = circular_a;
+    circular_a->ptr = circular_b;
+
     printf("A: %d\n", a);
     printf("B: %d\n", b); // sim:cprint stops here
     printf("C: %d\n", c);
@@ -92,4 +106,7 @@ int main() {
     printf("ENUM ONE: %d\n", enum_one);
     printf("ENUM TWO: %d\n", enum_two);
     printf("ENUM THREE: %d\n", enum_three);
+
+    printf("CIRCULAR_A: %d, %p\n", circular_a->value, circular_a->ptr);
+    printf("CIRCULAR_B: %d, %p\n", circular_b->value, circular_b->ptr);
 }

--- a/src/debugger/debugger.zig
+++ b/src/debugger/debugger.zig
@@ -2378,6 +2378,7 @@ fn DebuggerType(comptime AdapterType: anytype) type {
                     try pointers.put(params.scratch, address, types.ExpressionFieldNdx.from(original_len));
 
                     try self.renderVariableValue(fields, pointers, recursive_params);
+                    assert(fields.items.len > original_len);
 
                     // set the pointer value on the new field
                     assert(fields.items.len > original_len);

--- a/src/test/simulator.zig
+++ b/src/test/simulator.zig
@@ -2127,7 +2127,7 @@ test "sim:cprint" {
     const exe_path = "assets/cprint/out";
     const cprint_main_c_hash = try fileHash(t.allocator, "assets/cprint/main.c");
 
-    const expected_output_len = 308;
+    const expected_output_len = 362;
 
     // zig fmt: off
     sim.lock()
@@ -2159,7 +2159,7 @@ test "sim:cprint" {
         .send_after_ticks = 1,
         .req = (proto.UpdateBreakpointRequest{ .loc = .{ .source = .{
             .file_hash = cprint_main_c_hash,
-            .line = types.SourceLine.from(63),
+            .line = types.SourceLine.from(77),
         }}}).req(),
     })
 
@@ -2195,7 +2195,7 @@ test "sim:cprint" {
                         return false;
 
                     // spot check a few fields
-                    const num_locals = 22;
+                    const num_locals = 24;
                     if (!checkeq(usize, num_locals, paused.locals.len, "unexpected number of local variables") or
                         !checkeq(usize, num_locals, paused.locals.len, "unexpected number of local variable expression results") or
                         !checkeq(String, "a", paused.strings.get(paused.locals[0].expression) orelse "", "first local expression was incorrect") or


### PR DESCRIPTION
Protects against the case where a struct has a pointer chain that eventually refers back to itself. This would previously cause a stack overflow.

Obviously, the rendering of these pointer values needs to improve, but that will come later. Rendering structs that contain structs (or other non-primitive types) needs a re-think, and this is included in that.

![image](https://github.com/user-attachments/assets/252bfb5d-4d4f-4623-b0d5-3c0ab1678de6)
