### PR TITLE
style: remove redundant `@This()` calls to conform to more idiomatic Zig

### DIFF
--- a/assets/zigprint/main.zig
+++ b/assets/zigprint/main.zig
@@ -5,7 +5,7 @@ const MyStruct = struct {
     field_a: i32 = 123,
     field_b: []const u8 = "this is field_b",
 
-    fn dontOptimizeMe(_: *@This()) void {}
+    fn dontOptimizeMe(_: *MyStruct) void {}
 };
 
 const PackedStruct = packed struct {
@@ -13,7 +13,7 @@ const PackedStruct = packed struct {
     second: bool = true,
     third: u6 = 6,
 
-    fn dontOptimizeMe(_: *@This()) void {}
+    fn dontOptimizeMe(_: *PackedStruct) void {}
 };
 
 const ExternStruct = extern struct {
@@ -21,7 +21,7 @@ const ExternStruct = extern struct {
     second: bool = true,
     third: u8 = 6,
 
-    fn dontOptimizeMe(_: *@This()) void {}
+    fn dontOptimizeMe(_: *ExternStruct) void {}
 };
 
 const MyEnum = enum(i8) {
@@ -31,7 +31,7 @@ const MyEnum = enum(i8) {
     second,
     final = 100,
 
-    fn dontOptimizeMe(_: *@This()) void {}
+    fn dontOptimizeMe(_: *MyEnum) void {}
 };
 
 pub fn main() !void {

--- a/assets/zigsimple/main.zig
+++ b/assets/zigsimple/main.zig
@@ -5,7 +5,7 @@ const MyStruct = struct {
     field_a: i32 = 123,
     field_b: []const u8 = "this is field_b",
 
-    fn print(self: @This(), msg: []const u8) void {
+    fn print(self: MyStruct, msg: []const u8) void {
         std.debug.print(
             "{s}: .{{ .field_a = {}, .field_b = \"{s}\"}}\n",
             .{ msg, self.field_a, self.field_b },

--- a/src/MainAllocator.zig
+++ b/src/MainAllocator.zig
@@ -5,14 +5,14 @@ const Allocator = std.mem.Allocator;
 const assert = std.debug.assert;
 const heap = std.heap;
 
-const Self = @This();
+const MainAllocator = @This();
 
 gpa: heap.GeneralPurposeAllocator(.{}),
 alloc: Allocator,
 
-pub inline fn init() Self {
+pub inline fn init() MainAllocator {
     var gpa = heap.GeneralPurposeAllocator(.{}){};
-    return Self{
+    return .{
         .gpa = gpa,
         .alloc = switch (builtin.mode) {
             .Debug => gpa.allocator(),
@@ -21,10 +21,10 @@ pub inline fn init() Self {
     };
 }
 
-pub fn allocator(self: Self) Allocator {
+pub fn allocator(self: MainAllocator) Allocator {
     return self.alloc;
 }
 
-pub fn deinit(self: *Self) void {
+pub fn deinit(self: *MainAllocator) void {
     defer assert(self.gpa.deinit() == .ok);
 }

--- a/src/circularBuffer.zig
+++ b/src/circularBuffer.zig
@@ -14,7 +14,7 @@ pub fn CircularBuffer(comptime T: type) type {
         len: usize = 0,
 
         pub fn init(alloc: Allocator, size: usize) !Self {
-            return Self{ .items = try alloc.alloc(T, size) };
+            return .{ .items = try alloc.alloc(T, size) };
         }
 
         pub fn deinit(self: *Self, alloc: Allocator) void {

--- a/src/debugger/encoding/c.zig
+++ b/src/debugger/encoding/c.zig
@@ -8,12 +8,10 @@ const encoding = @import("encoding.zig");
 const strings = @import("../../strings.zig");
 const types = @import("../../types.zig");
 
-const Self = @This();
-
 const endian = builtin.cpu.arch.endian();
 
 pub fn encoder() encoding.Encoding {
-    return encoding.Encoding{
+    return .{
         .isString = isString,
         .renderString = renderString,
         .isSlice = isSlice,

--- a/src/debugger/encoding/encoding.zig
+++ b/src/debugger/encoding/encoding.zig
@@ -33,8 +33,6 @@ pub const EncodeVariableError = error{InvalidDataType} || error{ReadDataError} |
 /// that are not designed to have long lifetimes. All allocators passed to these functions must be scratch
 /// arenas, and the caller owns returned memory.
 pub const Encoding = struct {
-    const Self = @This();
-
     /// Returns null in the case that the symbol is not a string. Returns 0 if the length is unknown. Else,
     /// returns the length of the string as noted in the debug symbols.
     ///

--- a/src/debugger/encoding/zig.zig
+++ b/src/debugger/encoding/zig.zig
@@ -14,8 +14,6 @@ const types = @import("../../types.zig");
 
 const log = logging.Logger.init(logging.Region.Debugger);
 
-const Self = @This();
-
 const endian = builtin.cpu.arch.endian();
 
 pub fn encoder() encoding.Encoding {

--- a/src/debugger/proto.zig
+++ b/src/debugger/proto.zig
@@ -35,7 +35,7 @@ pub const Response = union(enum) {
 pub const GetStateRequest = struct {
     alloc: Allocator,
 
-    pub fn req(self: @This()) Request {
+    pub fn req(self: GetStateRequest) Request {
         return .{ .get_state = self };
     }
 };
@@ -45,8 +45,8 @@ pub const GetStateResponse = struct {
     /// All allocated memory lives in the corresponding GetStateRequest's allocator
     state: types.StateSnapshot,
 
-    pub fn resp(self: @This()) Response {
-        return Response{ .get_state = self };
+    pub fn resp(self: GetStateResponse) Response {
+        return .{ .get_state = self };
     }
 };
 
@@ -57,7 +57,7 @@ pub const GetStateResponse = struct {
 /// arena allocator totally separate from the Debugger allocator. This is probably not the best way
 /// of doing things, esp. once we support remote debugging.
 pub const StateUpdatedResponse = struct {
-    pub fn resp(self: @This()) Response {
+    pub fn resp(self: StateUpdatedResponse) Response {
         return .{ .state_updated = self };
     }
 };
@@ -67,7 +67,7 @@ pub const StateUpdatedResponse = struct {
 pub const LoadSymbolsRequest = struct {
     path: String,
 
-    pub fn req(self: @This()) Request {
+    pub fn req(self: LoadSymbolsRequest) Request {
         return .{ .load_symbols = self };
     }
 };
@@ -78,22 +78,22 @@ pub const LaunchSubordinateRequest = struct {
     args: String,
     stop_on_entry: bool,
 
-    pub fn req(self: @This()) Request {
-        return Request{ .launch = self };
+    pub fn req(self: LaunchSubordinateRequest) Request {
+        return .{ .launch = self };
     }
 };
 
 /// Force-kills the subordinate if it is running
 pub const KillSubordinateRequest = struct {
-    pub fn req(self: @This()) Request {
-        return Request{ .kill = self };
+    pub fn req(self: KillSubordinateRequest) Request {
+        return .{ .kill = self };
     }
 };
 
 /// Instructs the subordinate to continue execution if it was paused
 pub const ContinueRequest = struct {
-    pub fn req(self: @This()) Request {
-        return Request{ .cont = self };
+    pub fn req(self: ContinueRequest) Request {
+        return .{ .cont = self };
     }
 };
 
@@ -101,8 +101,8 @@ pub const ContinueRequest = struct {
 pub const StepRequest = struct {
     step_type: StepType,
 
-    pub fn req(self: @This()) Request {
-        return Request{ .step = self };
+    pub fn req(self: StepRequest) Request {
+        return .{ .step = self };
     }
 };
 
@@ -116,7 +116,7 @@ pub const StepType = enum(u8) {
 
 /// Quit shuts down the application
 pub const QuitRequest = struct {
-    pub fn req(self: @This()) Request {
+    pub fn req(self: QuitRequest) Request {
         return .{ .quit = self };
     }
 };
@@ -132,8 +132,8 @@ pub const UpdateBreakpointLocation = union(enum) {
 pub const ToggleBreakpointRequest = struct {
     id: types.BID,
 
-    pub fn req(self: @This()) Request {
-        return Request{ .toggle_breakpoint = self };
+    pub fn req(self: ToggleBreakpointRequest) Request {
+        return .{ .toggle_breakpoint = self };
     }
 };
 
@@ -141,8 +141,8 @@ pub const ToggleBreakpointRequest = struct {
 pub const UpdateBreakpointRequest = struct {
     loc: UpdateBreakpointLocation,
 
-    pub fn req(self: @This()) Request {
-        return Request{ .update_breakpoint = self };
+    pub fn req(self: UpdateBreakpointRequest) Request {
+        return .{ .update_breakpoint = self };
     }
 };
 
@@ -152,8 +152,8 @@ pub const ReceivedTextOutputResponse = struct {
     /// Memory is owned by the response queue's allocator.
     text: String,
 
-    pub fn resp(self: @This()) Response {
-        return Response{ .received_text_output = self };
+    pub fn resp(self: ReceivedTextOutputResponse) Response {
+        return .{ .received_text_output = self };
     }
 };
 
@@ -169,21 +169,21 @@ pub const SubordinateStoppedRequest = struct {
     /// should not stop the debugger (i.e. on Linux, window resize signals)
     should_stop_debugger: bool = true,
 
-    pub fn req(self: @This()) Request {
-        return Request{ .stopped = self };
+    pub fn req(self: SubordinateStoppedRequest) Request {
+        return .{ .stopped = self };
     }
 };
 
 /// Reset informs the GUI that the subordinate has been reset
 pub const ResetResponse = struct {
-    pub fn resp(self: @This()) Response {
+    pub fn resp(self: ResetResponse) Response {
         return .{ .reset = self };
     }
 };
 
 /// Informs the GUI that the symbols from the subordinate have been loaded and parsed
 pub const LoadSymbolsResponse = struct {
-    pub fn resp(self: @This()) Response {
+    pub fn resp(self: LoadSymbolsResponse) Response {
         return .{ .load_symbols = self };
     }
 
@@ -195,7 +195,7 @@ pub const LoadSymbolsResponse = struct {
 pub const SetHexWindowAddressRequest = struct {
     address: types.Address,
 
-    pub fn req(self: @This()) Request {
+    pub fn req(self: SetHexWindowAddressRequest) Request {
         return .{ .set_hex_window_address = self };
     }
 };
@@ -205,11 +205,11 @@ pub const SetWatchExpressionsRequest = struct {
     /// Memory is owned by the debugger thread
     expressions: []String,
 
-    pub fn req(self: @This()) Request {
+    pub fn req(self: SetWatchExpressionsRequest) Request {
         return .{ .set_watch_expressions = self };
     }
 
-    pub fn deinit(self: @This(), alloc: Allocator) void {
+    pub fn deinit(self: SetWatchExpressionsRequest, alloc: Allocator) void {
         for (self.expressions) |e| alloc.free(e);
         alloc.free(self.expressions);
     }

--- a/src/gui.zig
+++ b/src/gui.zig
@@ -1,1 +1,1 @@
-pub const run = @import("gui/GUI.zig").run;
+pub const run = @import("gui/Gui.zig").run;

--- a/src/gui/Gui.zig
+++ b/src/gui/Gui.zig
@@ -42,7 +42,7 @@ const icon_png = @embedFile("images/icon.png");
 pub const MaxFPS: u64 = 60;
 const FrameMicros: u64 = @divFloor(time.us_per_s, MaxFPS);
 
-const Self = @This();
+const Gui = @This();
 
 perm_alloc: Allocator,
 
@@ -58,7 +58,7 @@ main_dockspace_id: zui.ID = undefined,
 
 state: *State = undefined,
 
-fn init(alloc: Allocator, dbg: *Debugger) !*Self {
+fn init(alloc: Allocator, dbg: *Debugger) !*Gui {
     const z = trace.zoneN(@src(), "GUI.init");
     defer z.end();
 
@@ -203,10 +203,10 @@ fn init(alloc: Allocator, dbg: *Debugger) !*Self {
 
     _ = window.setKeyCallback(Input.keyCallback);
 
-    const self = try alloc.create(Self);
+    const self = try alloc.create(Gui);
     errdefer alloc.destroy(self);
 
-    self.* = Self{
+    self.* = Gui{
         .perm_alloc = alloc,
         .window = window,
     };
@@ -223,7 +223,7 @@ fn init(alloc: Allocator, dbg: *Debugger) !*Self {
     return self;
 }
 
-fn deinit(self: *Self) void {
+fn deinit(self: *Gui) void {
     const z = trace.zone(@src());
     defer z.end();
 
@@ -308,7 +308,7 @@ pub fn frameRateLimit(last_frame_render_micros: u64) u64 {
     return @intCast(time.microTimestamp());
 }
 
-fn render(self: *Self) void {
+fn render(self: *Gui) void {
     const z = trace.zone(@src());
     defer z.end();
 
@@ -316,7 +316,7 @@ fn render(self: *Self) void {
     self.window.swapBuffers();
 }
 
-fn setWindowSize(self: *Self, window: *glfw.Window) void {
+fn setWindowSize(self: *Gui, window: *glfw.Window) void {
     const z = trace.zone(@src());
     defer z.end();
 
@@ -347,7 +347,7 @@ fn windowResizedCallback(
     const z = trace.zone(@src());
     defer z.end();
 
-    const gui_null = window.getUserPointer(Self);
+    const gui_null = window.getUserPointer(Gui);
     assert(gui_null != null);
     gui_null.?.setWindowSize(window);
 }
@@ -360,13 +360,13 @@ pub const WindowSize = struct {
     h: f32,
 };
 
-pub fn getSingleFocusWindowSize(self: Self) WindowSize {
+pub fn getSingleFocusWindowSize(self: Gui) WindowSize {
     return self.getSingleFocusWindowSizeWithScale(0.95);
 }
 
 /// returns the width and height of a window that is almost full-screen,
 /// but has a bit of border padding around the edges
-pub fn getSingleFocusWindowSizeWithScale(self: Self, scale: f32) WindowSize {
+pub fn getSingleFocusWindowSizeWithScale(self: Gui, scale: f32) WindowSize {
     assert(scale >= 0);
     assert(scale <= 1);
 
@@ -388,11 +388,11 @@ pub fn getSingleFocusWindowSizeWithScale(self: Self, scale: f32) WindowSize {
     };
 }
 
-pub fn getMainDockspaceID(self: Self) zui.ID {
+pub fn getMainDockspaceID(self: Gui) zui.ID {
     return self.main_dockspace_id;
 }
 
-fn drawMenuBar(self: *Self) ?State.View {
+fn drawMenuBar(self: *Gui) ?State.View {
     const z = trace.zone(@src());
     defer z.end();
 

--- a/src/gui/views/Breakpoint.zig
+++ b/src/gui/views/Breakpoint.zig
@@ -4,7 +4,7 @@ const mem = std.mem;
 
 const debugger = @import("../../debugger.zig");
 const file = @import("../../file.zig");
-const GUI = @import("../GUI.zig");
+const GUI = @import("../Gui.zig");
 const Input = @import("../Input.zig");
 const logging = @import("../../logging.zig");
 const proto = debugger.proto;
@@ -15,31 +15,31 @@ const zui = @import("../zui.zig");
 
 const log = logging.Logger.init(logging.Region.GUI);
 
-const Self = @This();
+const Breakpoint = @This();
 
-gui: *State.GUIType,
+gui: *State.GuiType,
 state: *State,
 
-pub fn init(state: *State, gui: *State.GUIType) !*Self {
-    const self = try state.perm_alloc.create(Self);
+pub fn init(state: *State, gui: *State.GuiType) !*Breakpoint {
+    const self = try state.perm_alloc.create(Breakpoint);
     errdefer state.perm_alloc.free(self);
 
     self.* = .{ .state = state, .gui = gui };
     return self;
 }
 
-pub fn deinit(self: *Self) void {
+pub fn deinit(self: *Breakpoint) void {
     self.alloc.destroy(self);
 }
 
-pub fn view(self: *Self) State.View {
+pub fn view(self: *Breakpoint) State.View {
     const z = trace.zone(@src());
     defer z.end();
 
     return State.View{ .breakpoint = self };
 }
 
-fn handleInput(self: *Self) ?State.View {
+fn handleInput(self: *Breakpoint) ?State.View {
     const z = trace.zone(@src());
     defer z.end();
 
@@ -50,7 +50,7 @@ fn handleInput(self: *Self) ?State.View {
     return null;
 }
 
-pub fn update(self: *Self) State.View {
+pub fn update(self: *Breakpoint) State.View {
     const z = trace.zoneN(@src(), "Breakpoint.update");
     defer z.end();
 

--- a/src/gui/views/Primary.zig
+++ b/src/gui/views/Primary.zig
@@ -10,7 +10,7 @@ const t = std.testing;
 
 const colors = @import("../colors.zig");
 const debugger = @import("../../debugger.zig");
-const GUI = @import("../GUI.zig");
+const GUI = @import("../Gui.zig");
 const Input = @import("../Input.zig");
 const file_util = @import("../../file.zig");
 const logging = @import("../../logging.zig");
@@ -30,9 +30,9 @@ const time = @import("time");
 
 const log = logging.Logger.init(logging.Region.GUI);
 
-const Self = @This();
+const Primary = @This();
 
-gui: *State.GUIType,
+gui: *State.GuiType,
 state: *State,
 
 typing_in_textbox: bool = false,
@@ -47,11 +47,11 @@ focus_watch_var_input_on_next_frame: bool = false,
 
 open_windows: OpenWindows = .{},
 
-pub fn init(state: *State, gui: *State.GUIType) !*Self {
+pub fn init(state: *State, gui: *State.GuiType) !*Primary {
     const z = trace.zone(@src());
     defer z.end();
 
-    const self = try state.perm_alloc.create(Self);
+    const self = try state.perm_alloc.create(Primary);
     errdefer state.perm_alloc.destroy(self);
 
     self.* = .{
@@ -77,11 +77,11 @@ pub fn init(state: *State, gui: *State.GUIType) !*Self {
     return self;
 }
 
-pub fn toggleDiagnosticsView(self: *Self) void {
+pub fn toggleDiagnosticsView(self: *Primary) void {
     self.show_diagnostics = !self.show_diagnostics;
 }
 
-pub fn view(self: *Self) State.View {
+pub fn view(self: *Primary) State.View {
     const z = trace.zone(@src());
     defer z.end();
 
@@ -99,7 +99,7 @@ pub const OpenWindows = packed struct {
     diagnostics: bool = true,
 };
 
-fn handleInput(self: *Self) ?State.View {
+fn handleInput(self: *Primary) ?State.View {
     const z = trace.zone(@src());
     defer z.end();
 
@@ -190,7 +190,7 @@ fn handleInput(self: *Self) ?State.View {
     return null;
 }
 
-pub fn update(self: *Self) State.View {
+pub fn update(self: *Primary) State.View {
     const z = trace.zone(@src());
     defer z.end();
 
@@ -492,7 +492,7 @@ pub fn update(self: *Self) State.View {
     return self.view();
 }
 
-fn drawSpaceMenuHelp(self: *Self) void {
+fn drawSpaceMenuHelp(self: *Primary) void {
     const z = trace.zone(@src());
     defer z.end();
 
@@ -530,7 +530,7 @@ fn drawSpaceMenuHelp(self: *Self) void {
     }
 }
 
-fn displaySourceFiles(self: *Self) void {
+fn displaySourceFiles(self: *Primary) void {
     const z = trace.zone(@src());
     defer z.end();
 
@@ -724,7 +724,7 @@ test "countNumberOfDigits" {
 }
 
 // @TODO (jrc): this is all temporary and we will re-think the entire UX
-fn drawMainDockspace(self: *Self) void {
+fn drawMainDockspace(self: *Primary) void {
     const z = trace.zone(@src());
     defer z.end();
 
@@ -818,7 +818,7 @@ fn drawMainDockspace(self: *Self) void {
     zui.dockBuilderFinish(self.gui.getMainDockspaceID());
 }
 
-pub fn addWatchValue(self: *Self, val: []const u8) Allocator.Error!void {
+pub fn addWatchValue(self: *Primary, val: []const u8) Allocator.Error!void {
     if (val.len == 0) return;
 
     // copy to the heap
@@ -852,7 +852,7 @@ pub fn addWatchValue(self: *Self, val: []const u8) Allocator.Error!void {
 }
 
 fn renderExpressionResult(
-    self: *Self,
+    self: *Primary,
     scratch: Allocator,
     paused: *const types.PauseData,
     expr_res: types.ExpressionResult,

--- a/src/gui/watcher.zig
+++ b/src/gui/watcher.zig
@@ -18,8 +18,6 @@ pub const Watcher = switch (builtin.os.tag) {
 };
 
 const LinuxWatcher = struct {
-    const Self = @This();
-
     const IN = std.os.linux.IN;
     const posix = std.posix;
 
@@ -36,9 +34,9 @@ const LinuxWatcher = struct {
         fpath: []const u8,
         state: *State,
         callback: *const fn (*State) void,
-    ) !*Self {
-        const self = try alloc.create(Self);
-        self.* = Self{
+    ) !*LinuxWatcher {
+        const self = try alloc.create(LinuxWatcher);
+        self.* = LinuxWatcher{
             .fpath = try safe.copySlice(u8, alloc, fpath),
             .state = state,
             .callback = callback,
@@ -55,18 +53,18 @@ const LinuxWatcher = struct {
         return self;
     }
 
-    pub fn deinit(self: *Self, alloc: Allocator) void {
+    pub fn deinit(self: *LinuxWatcher, alloc: Allocator) void {
         // @TODO (jrc): stop background thread
         alloc.free(self.fpath);
         alloc.destroy(self);
     }
 
-    fn setupWatch(self: *Self) !void {
+    fn setupWatch(self: *LinuxWatcher) !void {
         self.ifd = try posix.inotify_init1(IN.NONBLOCK);
         self.wd = try posix.inotify_add_watch(self.ifd, self.fpath, IN.CLOSE_WRITE);
     }
 
-    fn pollEvents(self: *Self) void {
+    fn pollEvents(self: *LinuxWatcher) void {
         trace.initThread();
         defer trace.deinitThread();
 

--- a/src/gui/zui.zig
+++ b/src/gui/zui.zig
@@ -585,7 +585,7 @@ pub const StyleCol = enum(u32) {
     nav_windowing_dim_bg,
     modal_window_dim_bg,
 
-    pub fn int(self: @This()) usize {
+    pub fn int(self: StyleCol) usize {
         return @intFromEnum(self);
     }
 };

--- a/src/linux/dwarf.zig
+++ b/src/linux/dwarf.zig
@@ -45,15 +45,15 @@ pub const Version = enum(u4) {
     four = 4,
     five = 5,
 
-    pub fn int(self: @This()) u8 {
+    pub fn int(self: Version) u8 {
         return @intFromEnum(self);
     }
 
-    pub fn isLessThan(self: @This(), version: @This()) bool {
+    pub fn isLessThan(self: Version, version: Version) bool {
         return @intFromEnum(self) < @intFromEnum(version);
     }
 
-    pub fn isAtLeast(self: @This(), version: @This()) bool {
+    pub fn isAtLeast(self: Version, version: Version) bool {
         return @intFromEnum(self) >= @intFromEnum(version);
     }
 };

--- a/src/linux/dwarf/abbrev.zig
+++ b/src/linux/dwarf/abbrev.zig
@@ -25,7 +25,7 @@ pub const Table = struct {
     offset: Offset,
     decls: AutoHashMapUnmanaged(Code, *Decl) = .{},
 
-    pub fn getDecl(self: @This(), code: Code) error{InvalidDWARFInfo}!*Decl {
+    pub fn getDecl(self: Table, code: Code) error{InvalidDWARFInfo}!*Decl {
         const decl = self.decls.get(code);
         if (decl) |d| return d;
 
@@ -48,7 +48,7 @@ pub const Attr = struct {
     /// Determines which FormType to use for the given Attr, and advances the
     /// reader by the appropriate number of bytes
     pub fn chooseFormAndAdvanceBySize(
-        self: @This(),
+        self: Attr,
         val: *FormValue,
         cu: *info.CompileUnit,
     ) dwarf.ParseError!void {
@@ -708,7 +708,7 @@ pub const FormValue = struct {
     form: FormType,
     class: FormClass,
 
-    pub fn parseNumeric(self: @This(), comptime T: type, cu: *const info.CompileUnit) error{InvalidDWARFInfo}!T {
+    pub fn parseNumeric(self: FormValue, comptime T: type, cu: *const info.CompileUnit) error{InvalidDWARFInfo}!T {
         return switch (self.form) {
             .string => {
                 log.errf("cannot parse form type {s} to numeric", .{@tagName(self.name)});
@@ -741,7 +741,7 @@ pub const FormClass = enum(u8) {
     string,
     stroffsetptr,
 
-    pub fn contents(self: @This(), cu: *const info.CompileUnit, offset: Offset) error{InvalidDWARFInfo}![]const u8 {
+    pub fn contents(self: FormClass, cu: *const info.CompileUnit, offset: Offset) error{InvalidDWARFInfo}![]const u8 {
         const buf = switch (self) {
             .address, .reference => cu.opts.sections.info.contents,
             .addrptr => cu.opts.sections.addr.contents,
@@ -798,10 +798,10 @@ pub const FormType = union(enum) {
 
 pub const FormU8 = struct {
     pub fn formType() FormType {
-        return FormType{ .u8 = @This(){} };
+        return .{ .u8 = .{} };
     }
 
-    pub fn parse(_: @This(), cu: *const info.CompileUnit, offset: Offset) error{InvalidDWARFInfo}!u8 {
+    pub fn parse(_: FormU8, cu: *const info.CompileUnit, offset: Offset) error{InvalidDWARFInfo}!u8 {
         try numericFormBoundsCheck(u8, cu.opts.sections.info.contents, offset);
         return mem.bytesToValue(u8, cu.opts.sections.info.contents[offset..]);
     }
@@ -809,10 +809,10 @@ pub const FormU8 = struct {
 
 pub const FormU16 = struct {
     pub fn formType() FormType {
-        return FormType{ .u16 = @This(){} };
+        return .{ .u16 = .{} };
     }
 
-    pub fn parse(_: @This(), cu: *const info.CompileUnit, offset: Offset) error{InvalidDWARFInfo}!u16 {
+    pub fn parse(_: FormU16, cu: *const info.CompileUnit, offset: Offset) error{InvalidDWARFInfo}!u16 {
         try numericFormBoundsCheck(u16, cu.opts.sections.info.contents, offset);
         return mem.bytesToValue(u16, cu.opts.sections.info.contents[offset..]);
     }
@@ -820,10 +820,10 @@ pub const FormU16 = struct {
 
 pub const FormU32 = struct {
     pub fn formType() FormType {
-        return FormType{ .u32 = @This(){} };
+        return .{ .u32 = .{} };
     }
 
-    pub fn parse(_: @This(), cu: *const info.CompileUnit, offset: Offset) error{InvalidDWARFInfo}!u32 {
+    pub fn parse(_: FormU32, cu: *const info.CompileUnit, offset: Offset) error{InvalidDWARFInfo}!u32 {
         try numericFormBoundsCheck(u32, cu.opts.sections.info.contents, offset);
         return mem.bytesToValue(u32, cu.opts.sections.info.contents[offset..]);
     }
@@ -831,10 +831,10 @@ pub const FormU32 = struct {
 
 pub const FormU64 = struct {
     pub fn formType() FormType {
-        return FormType{ .u64 = @This(){} };
+        return .{ .u64 = .{} };
     }
 
-    pub fn parse(_: @This(), cu: *const info.CompileUnit, offset: Offset) error{InvalidDWARFInfo}!u64 {
+    pub fn parse(_: FormU64, cu: *const info.CompileUnit, offset: Offset) error{InvalidDWARFInfo}!u64 {
         try numericFormBoundsCheck(u64, cu.opts.sections.info.contents, offset);
         return mem.bytesToValue(u64, cu.opts.sections.info.contents[offset..]);
     }
@@ -842,10 +842,10 @@ pub const FormU64 = struct {
 
 pub const FormI8 = struct {
     pub fn formType() FormType {
-        return FormType{ .i8 = @This(){} };
+        return .{ .i8 = .{} };
     }
 
-    pub fn parse(_: @This(), cu: *const info.CompileUnit, offset: Offset) error{InvalidDWARFInfo}!i8 {
+    pub fn parse(_: FormI8, cu: *const info.CompileUnit, offset: Offset) error{InvalidDWARFInfo}!i8 {
         try numericFormBoundsCheck(i8, cu.opts.sections.info.contents, offset);
         return mem.bytesToValue(i8, cu.opts.sections.info.contents[offset..]);
     }
@@ -853,10 +853,10 @@ pub const FormI8 = struct {
 
 pub const FormI16 = struct {
     pub fn formType() FormType {
-        return FormType{ .i16 = @This(){} };
+        return .{ .i16 = .{} };
     }
 
-    pub fn parse(_: @This(), cu: *const info.CompileUnit, offset: Offset) error{InvalidDWARFInfo}!i16 {
+    pub fn parse(_: FormI16, cu: *const info.CompileUnit, offset: Offset) error{InvalidDWARFInfo}!i16 {
         try numericFormBoundsCheck(i16, cu.opts.sections.info.contents, offset);
         return mem.bytesToValue(i16, cu.opts.sections.info.contents[offset..]);
     }
@@ -864,10 +864,10 @@ pub const FormI16 = struct {
 
 pub const FormI32 = struct {
     pub fn formType() FormType {
-        return FormType{ .i32 = @This(){} };
+        return .{ .i32 = .{} };
     }
 
-    pub fn parse(_: @This(), cu: *const info.CompileUnit, offset: Offset) error{InvalidDWARFInfo}!i32 {
+    pub fn parse(_: FormI32, cu: *const info.CompileUnit, offset: Offset) error{InvalidDWARFInfo}!i32 {
         try numericFormBoundsCheck(i32, cu.opts.sections.info.contents, offset);
         return mem.bytesToValue(i32, cu.opts.sections.info.contents[offset..]);
     }
@@ -875,10 +875,10 @@ pub const FormI32 = struct {
 
 pub const FormI64 = struct {
     pub fn formType() FormType {
-        return FormType{ .i64 = @This(){} };
+        return .{ .i64 = .{} };
     }
 
-    pub fn parse(_: @This(), cu: *const info.CompileUnit, offset: Offset) error{InvalidDWARFInfo}!i64 {
+    pub fn parse(_: FormI64, cu: *const info.CompileUnit, offset: Offset) error{InvalidDWARFInfo}!i64 {
         try numericFormBoundsCheck(i64, cu.opts.sections.info.contents, offset);
         return mem.bytesToValue(i64, cu.opts.sections.info.contents[offset..]);
     }
@@ -886,10 +886,10 @@ pub const FormI64 = struct {
 
 pub const FormOffset = struct {
     pub fn formType() FormType {
-        return FormType{ .offset = @This(){} };
+        return .{ .offset = .{} };
     }
 
-    pub fn parse(_: @This(), cu: *const info.CompileUnit, offset: Offset) error{InvalidDWARFInfo}!Offset {
+    pub fn parse(_: FormOffset, cu: *const info.CompileUnit, offset: Offset) error{InvalidDWARFInfo}!Offset {
         if (cu.header.is_32_bit) {
             try numericFormBoundsCheck(u32, cu.opts.sections.info.contents, offset);
             return mem.bytesToValue(u32, cu.opts.sections.info.contents[offset..]);
@@ -901,18 +901,15 @@ pub const FormOffset = struct {
 };
 
 pub const FormString = struct {
-    len: usize,
     section: FormStringSection,
+    len: usize,
 
     pub fn formType(section: FormStringSection, len: usize) FormType {
-        return FormType{ .string = @This(){
-            .len = len,
-            .section = section,
-        } };
+        return .{ .string = .{ .len = len, .section = section } };
     }
 
     /// Returns a slice in to the existing debug_info_contents array, so no allocations are performed
-    pub fn parse(self: @This(), cu: *const info.CompileUnit, offset: Offset) error{InvalidDWARFInfo}![]const u8 {
+    pub fn parse(self: FormString, cu: *const info.CompileUnit, offset: Offset) error{InvalidDWARFInfo}![]const u8 {
         const section_data = self.section.contents(cu.opts.sections);
 
         const end = offset + self.len;
@@ -934,10 +931,10 @@ pub const FormStored = struct {
     val: i128,
 
     pub fn formType(val: i128) FormType {
-        return FormType{ .stored = @This(){ .val = val } };
+        return .{ .stored = .{ .val = val } };
     }
 
-    pub fn parse(self: @This(), _: *const info.CompileUnit, _: Offset) error{InvalidDWARFInfo}!i128 {
+    pub fn parse(self: FormStored, _: *const info.CompileUnit, _: Offset) error{InvalidDWARFInfo}!i128 {
         return self.val;
     }
 };
@@ -966,7 +963,7 @@ pub const FormStringSection = enum(u8) {
     str_offsets,
     types,
 
-    pub fn contents(self: @This(), sections: *const dwarf.Sections) []const u8 {
+    pub fn contents(self: FormStringSection, sections: *const dwarf.Sections) []const u8 {
         return switch (self) {
             .abbrev => return sections.abbrev.contents,
             .line => return sections.line.contents,

--- a/src/linux/dwarf/consts.zig
+++ b/src/linux/dwarf/consts.zig
@@ -466,7 +466,7 @@ pub const Language = enum(u16) {
     DW_LANG_Jai = 0xb103,
     DW_LANG_Odin = 0xb104,
 
-    pub fn fromProducer(producer: []const u8) ?@This() {
+    pub fn fromProducer(producer: []const u8) ?Language {
         if (mem.startsWith(u8, producer, "zig")) return .DW_LANG_Zig;
         if (mem.startsWith(u8, producer, "odin")) return .DW_LANG_Odin;
         if (mem.containsAtLeast(u8, producer, 1, "Jai")) return .DW_LANG_Jai;
@@ -474,7 +474,7 @@ pub const Language = enum(u16) {
         return null;
     }
 
-    pub fn toGeneric(self: @This()) error{LanguageUnsupported}!types.Language {
+    pub fn toGeneric(self: Language) error{LanguageUnsupported}!types.Language {
         return switch (self) {
             .DW_LANG_C,
             .DW_LANG_C89,
@@ -503,7 +503,7 @@ pub const Language = enum(u16) {
         };
     }
 
-    pub fn str(self: @This()) []const u8 {
+    pub fn str(self: Language) []const u8 {
         return switch (self) {
             .DW_LANG_C,
             .DW_LANG_C89,
@@ -627,7 +627,7 @@ pub const LineNumberOpcodes = enum(u8) {
     set_epilogue_begin = 11,
     set_isa = 12,
 
-    pub fn knownLen(self: @This()) ?u8 {
+    pub fn knownLen(self: LineNumberOpcodes) ?u8 {
         return switch (self) {
             .copy => 0,
             .advance_pc => 1,
@@ -779,7 +779,7 @@ pub const UnwindRegisterRule = enum(u8) {
     /// Register is computed value
     val_expr,
 
-    pub fn int(self: @This()) u8 {
+    pub fn int(self: UnwindRegisterRule) u8 {
         return @intFromEnum(self);
     }
 };
@@ -803,7 +803,7 @@ pub const Registers = enum(u8) {
     r15,
     rip,
 
-    pub fn int(self: @This()) u8 {
+    pub fn int(self: Registers) u8 {
         return @intFromEnum(self);
     }
 };
@@ -1023,7 +1023,7 @@ pub const ExpressionOpcode = enum(u8) {
     pub const lo_user = 0xe0; // Implementation-defined range start.
     pub const hi_user = 0xff; // Implementation-defined range end.
 
-    pub fn int(self: @This()) u8 {
+    pub fn int(self: ExpressionOpcode) u8 {
         return @intFromEnum(self);
     }
 };

--- a/src/linux/elf.zig
+++ b/src/linux/elf.zig
@@ -256,9 +256,7 @@ pub const HeaderData = struct {
     // the list of section headers and the data of each section
     sections: ArrayList(Section) = undefined,
 
-    const Self = *@This();
-
-    fn sectionHeaderByName(self: Self, name: String) ?Section {
+    fn sectionHeaderByName(self: *HeaderData, name: String) ?Section {
         for (self.sections.items) |section| {
             if (strings.eql(section.name, name)) {
                 return section;

--- a/src/linux/unwind.zig
+++ b/src/linux/unwind.zig
@@ -49,7 +49,7 @@ pub fn stack(
     regs: *const arch.Registers,
     load_addr: types.Address,
     addr_size: types.AddressSize,
-    cie: *const frame.CIE,
+    cie: *const frame.Cie,
     depth: ?u32, // null indicates that we should unwind the entire stack
 ) !types.UnwindResult {
     const z = trace.zone(@src());
@@ -130,8 +130,8 @@ const UnwindData = struct {
 
     first_iteration: bool = true,
 
-    cie: *const frame.CIE,
-    fde: *const frame.FDE = undefined,
+    cie: *const frame.Cie,
+    fde: *const frame.Fde = undefined,
 };
 
 fn calculateFrameAddress(adapter: *Adapter, unwind: *UnwindData) !void {
@@ -343,7 +343,7 @@ fn getCFA(table: *FrameTable) i128 {
 
 fn parseUnwindProgram(
     scratch: Allocator,
-    cie: *const frame.CIE,
+    cie: *const frame.Cie,
     base_addr: types.Address,
     instructions_r: *Reader,
     table: *FrameTable,

--- a/src/queue.zig
+++ b/src/queue.zig
@@ -33,7 +33,7 @@ pub fn Queue(comptime T: anytype) type {
         cond: Condition = .{},
 
         pub fn init(tsa: *heap.ThreadSafeAllocator, opts: Options) Self {
-            return Self{
+            return .{
                 .alloc = tsa.allocator(),
                 .opts = opts,
             };

--- a/src/settings.zig
+++ b/src/settings.zig
@@ -35,7 +35,7 @@ const Global = struct {
     display: Display = Display{},
     rust: Rust = Rust{},
 
-    fn mapEntry(global: *@This(), allocator: Allocator, entry: *const IniEntry) !void {
+    fn mapEntry(global: *Global, allocator: Allocator, entry: *const IniEntry) !void {
         if (mem.eql(u8, entry.section, "log")) {
             try global.log.mapEntry(allocator, entry);
             return;
@@ -62,7 +62,7 @@ const Log = struct {
     /// The absolute path to the file where logs will be written
     file: []const u8 = "/tmp/uscope.log",
 
-    fn mapEntry(self: *@This(), allocator: Allocator, entry: *const IniEntry) !void {
+    fn mapEntry(self: *Log, allocator: Allocator, entry: *const IniEntry) !void {
         if (mem.eql(u8, entry.key, "color")) {
             self.color = try parseBool(entry.val);
             return;
@@ -108,7 +108,7 @@ const Rust = struct {
     /// (i.e. /home/user/.cargo/registry/src/)
     cargo: []const u8 = "",
 
-    fn mapEntry(self: *@This(), allocator: Allocator, entry: *const IniEntry) !void {
+    fn mapEntry(self: *Rust, allocator: Allocator, entry: *const IniEntry) !void {
         if (mem.eql(u8, entry.key, "stdlib")) {
             self.stdlib = try allocString(allocator, mem.trimRight(u8, entry.val, "/"));
             return;
@@ -125,7 +125,7 @@ const Project = struct {
 
     target: Target = Target{},
 
-    fn mapEntry(project: *@This(), allocator: Allocator, entry: *const IniEntry) !void {
+    fn mapEntry(project: *Project, allocator: Allocator, entry: *const IniEntry) !void {
         if (mem.eql(u8, entry.section, "sources")) {
             try project.sources.mapEntry(allocator, entry);
             return;
@@ -150,7 +150,7 @@ const Sources = struct {
     /// matching entry in `open_files`.
     breakpoint_lines: [][]usize = &.{},
 
-    fn mapEntry(self: *@This(), allocator: Allocator, entry: *const IniEntry) !void {
+    fn mapEntry(self: *Sources, allocator: Allocator, entry: *const IniEntry) !void {
         if (mem.eql(u8, entry.key, "open_files")) {
             const entries = try allocStringSlice(allocator, entry.val);
             errdefer allocator.free(entries);
@@ -205,7 +205,7 @@ const Target = struct {
     /// The default set of expressions to use in the watch window
     watch_expressions: [][]const u8 = &.{},
 
-    fn mapEntry(self: *@This(), allocator: Allocator, entry: *const IniEntry) !void {
+    fn mapEntry(self: *Target, allocator: Allocator, entry: *const IniEntry) !void {
         if (mem.eql(u8, entry.key, "path")) {
             self.path = try allocString(allocator, entry.val);
             return;

--- a/src/strings.zig
+++ b/src/strings.zig
@@ -39,15 +39,13 @@ pub fn hash(str: String) Hash {
 
 /// A simple data structure used to do string interning
 pub const Cache = struct {
-    const Self = @This();
-
     alloc: Allocator,
     arena: *ArenaAllocator,
 
     mu: Mutex = .{},
     map: AutoHashMapUnmanaged(Hash, String) = .{},
 
-    pub fn init(alloc: Allocator) Allocator.Error!*Self {
+    pub fn init(alloc: Allocator) Allocator.Error!*Cache {
         const z = trace.zone(@src());
         defer z.end();
 
@@ -58,7 +56,7 @@ pub const Cache = struct {
             alloc.destroy(arena);
         }
 
-        const self = try alloc.create(Self);
+        const self = try alloc.create(Cache);
         errdefer alloc.destroy(self);
         self.* = .{
             .arena = arena,
@@ -67,7 +65,7 @@ pub const Cache = struct {
         return self;
     }
 
-    pub fn deinit(self: *Self, alloc: Allocator) void {
+    pub fn deinit(self: *Cache, alloc: Allocator) void {
         const z = trace.zone(@src());
         defer z.end();
 
@@ -84,7 +82,7 @@ pub const Cache = struct {
 
     /// Allocates and does a full copy of every string in the given Cache. Caller
     /// owns returned memory, and the existing cache is still valid after copy.
-    pub fn copy(self: *Self, alloc: Allocator) Allocator.Error!*Self {
+    pub fn copy(self: *Cache, alloc: Allocator) Allocator.Error!*Cache {
         const z = trace.zone(@src());
         defer z.end();
 
@@ -105,7 +103,7 @@ pub const Cache = struct {
     /// Inserts an item in to the cache, returning its cache key. It allocates
     /// and stores a local copy of the string, so the caller is free to do what
     /// it wants with the passed `str`.
-    pub fn add(self: *Self, str: String) Allocator.Error!Hash {
+    pub fn add(self: *Cache, str: String) Allocator.Error!Hash {
         const z = trace.zone(@src());
         defer z.end();
 
@@ -126,7 +124,7 @@ pub const Cache = struct {
     /// quick-and-dirty lookups of Strings in the table. If the caller wishes to hold
     /// on to the String, use `getOwned`, which will take a copy of the String in the
     /// passed allocator (if any String is found).
-    pub fn get(self: *Self, hsh: Hash) ?String {
+    pub fn get(self: *Cache, hsh: Hash) ?String {
         const z = trace.zone(@src());
         defer z.end();
 
@@ -137,7 +135,7 @@ pub const Cache = struct {
     }
 
     /// Caller owns returned memory, if the String is found
-    pub fn getOwned(self: *Self, alloc: Allocator, hsh: Hash) Allocator.Error!?String {
+    pub fn getOwned(self: *Cache, alloc: Allocator, hsh: Hash) Allocator.Error!?String {
         const z = trace.zone(@src());
         defer z.end();
 

--- a/src/trace.zig
+++ b/src/trace.zig
@@ -39,7 +39,7 @@ pub fn zoneN(comptime src: Src, comptime name: [:0]const u8) ZoneCtx {
 pub const ZoneCtx = struct {
     tracy_ctx: tracy.ZoneCtx,
 
-    pub fn end(self: @This()) void {
+    pub fn end(self: ZoneCtx) void {
         spall.end();
         self.tracy_ctx.End();
     }

--- a/src/x86/x86.zig
+++ b/src/x86/x86.zig
@@ -6,8 +6,6 @@ const types = @import("../types.zig");
 pub const InterruptInstruction = 0xcc;
 
 pub const Registers = extern struct {
-    const Self = @This();
-
     R15: u64 = 0,
     R14: u64 = 0,
     R13: u64 = 0,
@@ -36,25 +34,25 @@ pub const Registers = extern struct {
     Fs: u64 = 0,
     Gs: u64 = 0,
 
-    pub fn pc(self: Self) types.Address {
+    pub fn pc(self: Registers) types.Address {
         return types.Address.from(self.Rip);
     }
 
-    pub fn setPC(self: *Self, val: types.Address) void {
+    pub fn setPC(self: *Registers, val: types.Address) void {
         self.Rip = val.int();
     }
 
-    pub fn bp(self: Self) types.Address {
+    pub fn bp(self: Registers) types.Address {
         return types.Address.from(self.Rbp);
     }
 
-    pub fn sp(self: Self) types.Address {
+    pub fn sp(self: Registers) types.Address {
         return types.Address.from(self.Rsp);
     }
 
     /// Implements platform-specific logic to retrieve the value of a registeer
     /// given an ID that is meaningful for a given target
-    pub fn fromID(self: *const Self, id: u64) error{UnexpectedValue}!u64 {
+    pub fn fromID(self: *const Registers, id: u64) error{UnexpectedValue}!u64 {
         switch (builtin.os.tag) {
             .linux => {
                 const DWARFRegs = @import("../linux/dwarf/consts.zig").Registers;


### PR DESCRIPTION
Hi, @jcalabro, really awesome project! Nice work tackling DWARF parsing from scratch for this proper source-level GUI debugger. I've played around with a toy assembly-level debugger recently, which I called *dobby* because it was an *ELF* debugger - so fun :)

Anyway, just wanted to contribute some stylistic fixes to make the codebase a bit more consistent and idiomatic:

- I've noticed that you use `@This()` in simple structs, but it's actually unnecessary since you can use the type's name directly (see [Loris' zig.news blog post](https://zig.news/kristoff/dont-self-simple-structs-fj8)). The reason for preferring to use less `@This()` is mainly readability, especially in the case of nested structs.

- In terms of naming, acronyms are more readable if they remain consistent with other naming rules (see [Zig's official style guide's "Names" section](https://ziglang.org/documentation/0.13.0/#Names)), for instance: parseEHFrameFDE -> parseEhFrameFde (acronyms are still clear *and* the "camelCaseFunctionNames" rule is preserved).