### PR TITLE
Handle Opaque Pointers

### DIFF
--- a/assets/zigprint/main.zig
+++ b/assets/zigprint/main.zig
@@ -100,6 +100,8 @@ pub fn main() !void {
     const av = MyEnum.second;
     const aw = MyEnum.final;
 
+    const opaque_ptr: *anyopaque = @ptrFromInt(0x123);
+
     print("{}\n", .{a});
     print("{}\n", .{b});
     print("{}\n", .{c}); // sim:zigprint stops here
@@ -157,4 +159,6 @@ pub fn main() !void {
     print("{s}\n", .{@tagName(au)});
     print("{s}\n", .{@tagName(av)});
     print("{s}\n", .{@tagName(aw)});
+
+    print("{any}\n", .{opaque_ptr});
 }

--- a/src/debugger/debugger.zig
+++ b/src/debugger/debugger.zig
@@ -2341,7 +2341,7 @@ fn DebuggerType(comptime AdapterType: anytype) type {
 
                     // the pointer is opaque, so we can't do anything other than render
                     // its address, which may still be useful to the user
-                    if (base_data_type_ndx == null) {
+                    if (base_data_type_ndx == null or params.encoder.isOpaquePointer(enc_params)) {
                         try fields.append(params.scratch, .{
                             .address = address,
                             .data = null,

--- a/src/debugger/encoding/C.zig
+++ b/src/debugger/encoding/C.zig
@@ -14,11 +14,16 @@ const endian = builtin.cpu.arch.endian();
 
 pub fn encoder() encoding.Encoding {
     return encoding.Encoding{
+        .isOpaquePointer = isOpaquePointer,
         .isString = isString,
         .renderString = renderString,
         .isSlice = isSlice,
         .renderSlice = renderSlice,
     };
+}
+
+fn isOpaquePointer(_: *const encoding.Params) bool {
+    return false;
 }
 
 fn isString(params: *const encoding.Params) ?usize {

--- a/src/debugger/encoding/Zig.zig
+++ b/src/debugger/encoding/Zig.zig
@@ -20,11 +20,16 @@ const endian = builtin.cpu.arch.endian();
 
 pub fn encoder() encoding.Encoding {
     return encoding.Encoding{
+        .isOpaquePointer = isOpaquePointer,
         .isString = isString,
         .renderString = renderString,
         .isSlice = isSlice,
         .renderSlice = renderSlice,
     };
+}
+
+fn isOpaquePointer(params: *const encoding.Params) bool {
+    return strings.eql(params.data_type_name, "*anyopaque");
 }
 
 fn isString(params: *const encoding.Params) ?u64 {

--- a/src/debugger/encoding/encoding.zig
+++ b/src/debugger/encoding/encoding.zig
@@ -35,6 +35,8 @@ pub const EncodeVariableError = error{InvalidDataType} || error{ReadDataError} |
 pub const Encoding = struct {
     const Self = @This();
 
+    isOpaquePointer: *const fn (params: *const Params) bool,
+
     /// Returns null in the case that the symbol is not a string. Returns 0 if the length is unknown. Else,
     /// returns the length of the string as noted in the debug symbols.
     ///

--- a/src/gui/views/Primary.zig
+++ b/src/gui/views/Primary.zig
@@ -882,8 +882,10 @@ fn renderExpressionResult(
                 .primitive => |p| {
                     switch (p.encoding) {
                         .string => {
-                            if (paused.strings.get(field.data.?)) |data| {
-                                zui.textWrapped("(len: {d})", .{data.len});
+                            if (field.data) |str_hash| {
+                                if (paused.strings.get(str_hash)) |data| {
+                                    zui.textWrapped("(len: {d})", .{data.len});
+                                }
                             }
                         },
                         else => {},
@@ -1033,9 +1035,7 @@ fn renderWatchInteger(scratch: Allocator, buf: []const u8, signedness: types.Sig
         4 => if (signedness == .signed) try r.read(i32) else try r.read(u32),
         8 => if (signedness == .signed) try r.read(i64) else try r.read(u64),
         16 => try r.read(i128),
-        else => {
-            return error.InvalidIntegerSize;
-        },
+        else => return error.InvalidIntegerSize,
     };
 
     return try fmt.allocPrint(scratch, "{d}", .{n});

--- a/src/test/simulator.zig
+++ b/src/test/simulator.zig
@@ -618,7 +618,7 @@ test "sim:zigprint" {
     const exe_path = "assets/zigprint/out";
     const zigprint_main_zig_hash = try fileHash(t.allocator, "assets/zigprint/main.zig");
 
-    const expected_output_len = 464;
+    const expected_output_len = 478;
 
     // zig fmt: off
     sim.lock()
@@ -650,7 +650,7 @@ test "sim:zigprint" {
         .send_after_ticks = 1,
         .req = (proto.UpdateBreakpointRequest{ .loc = .{ .source = .{
             .file_hash = zigprint_main_zig_hash,
-            .line = types.SourceLine.from(105),
+            .line = types.SourceLine.from(107),
         }}}).req(),
     })
 
@@ -693,7 +693,7 @@ test "sim:zigprint" {
                         if (s.state.subordinate_output.len == 0) return null;
 
                         // spot check a few fields
-                        const num_locals = 49;
+                        const num_locals = 50;
                         if (checkeq(usize, 4, s.state.subordinate_output.len, "unexpected program output len") and
                             checkeq(usize, num_locals, paused.locals.len, "unexpected number of local variables") and
                             checkeq(usize, num_locals, paused.locals.len, "unexpected number of local variable expression results") and
@@ -708,6 +708,13 @@ test "sim:zigprint" {
                                 if (!checkstr(paused.strings, "abcd", data_hash, "unexpected render value for field \"ao\"")) {
                                     return false;
                                 }
+                            }
+
+                            {
+                                // test rendering an opaque pointer
+                                const opaque_ptr = paused.getLocalByName("opaque_ptr") orelse return falseWithErr("unable to get local \"opaque_ptr\"", .{});
+                                if (opaque_ptr.fields[0].data != null) return falseWithErr("data should not set on variable \"opaque_ptr\"", .{});
+                                if (opaque_ptr.fields[0].address == null) return falseWithErr("address should be set on variable \"opaque_ptr\"", .{});
                             }
 
                             {


### PR DESCRIPTION
See also #9, though I don't think/know that is actually fixes the full issue cc: @leroycep 

Enables rendering opaque pointers in the debugger. In this case, we just send a null value to the UI plus an address. If desired, the user can click the address to send it to the hex window and poke around with the contents of the pointer's memory.

The reason I had to add a full `isOpaquePointer` check to the encoder interface is because Zig with the LLVM backend spits out:

```
< 1><0x00001010>    DW_TAG_base_type
                      DW_AT_name                  anyopaque
                      DW_AT_encoding              DW_ATE_signed
                      DW_AT_byte_size             0
```

Which sadly necessitates looking at the language in use by the given compile unit as well as the name of the type.

![image](https://github.com/user-attachments/assets/2739e3fc-8100-4aaa-aaa2-4c3d3e6041ab)