### PR TITLE
Nested Data Rendering Bugfixes

### DIFF
--- a/assets/zigprint/main.zig
+++ b/assets/zigprint/main.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const ArrayList = std.ArrayList;
 const print = std.debug.print;
 
 const MyStruct = struct {
@@ -127,6 +128,18 @@ pub fn main() !void {
     var bb = NestedStruct{ .nested = ap };
     bb.dontOptimizeMe();
 
+    var bd = NestedStruct{ .nested = .{
+        .field_a = 99,
+        .field_b = "another string",
+    } };
+    bd.dontOptimizeMe();
+
+    var be = ArrayList(NestedStruct).init(std.heap.page_allocator);
+    defer be.deinit();
+    try be.append(bb);
+    try be.append(bd);
+    try be.append(bb);
+
     print("{}\n", .{a});
     print("{}\n", .{b});
     print("{}\n", .{c}); // sim:zigprint stops here
@@ -192,4 +205,6 @@ pub fn main() !void {
     print("{any}\n", .{ba});
 
     print("{any}\n", .{bb});
+
+    print("{any}\n", .{be.items.len});
 }

--- a/assets/zigprint/main.zig
+++ b/assets/zigprint/main.zig
@@ -9,8 +9,8 @@ const MyStruct = struct {
 };
 
 const NestedStruct = struct {
-    first: i32 = 456,
-    second: MyStruct,
+    numeric: i32 = 456,
+    nested: MyStruct,
 
     fn dontOptimizeMe(_: *@This()) void {}
 };
@@ -124,7 +124,7 @@ pub fn main() !void {
     var ba = TaggedUnion{ .third = &ap };
     ba.dontOptimizeMe();
 
-    var bb = NestedStruct{ .second = ap };
+    var bb = NestedStruct{ .nested = ap };
     bb.dontOptimizeMe();
 
     print("{}\n", .{a});

--- a/src/debugger/debugger.zig
+++ b/src/debugger/debugger.zig
@@ -2321,6 +2321,18 @@ fn DebuggerType(comptime AdapterType: anytype) type {
                         },
                     };
 
+                    if (address.eqlInt(0)) {
+                        // not sure what to do, just bail out
+                        try fields.append(params.scratch, .{
+                            .address = address,
+                            .data = null,
+                            .data_type_name = try self.data.subordinate.?.paused.?.strings.add(data_type_name),
+                            .name = try self.data.subordinate.?.paused.?.strings.add(var_name),
+                            .encoding = .{ .primitive = .{ .encoding = .string } },
+                        });
+                        return;
+                    }
+
                     // check if we've seen this pointer before for this variable
                     if (pointers.get(address)) |field_ndx| {
                         const original_pointer_field = fields.items[field_ndx.int()];

--- a/src/debugger/debugger.zig
+++ b/src/debugger/debugger.zig
@@ -2437,10 +2437,11 @@ fn DebuggerType(comptime AdapterType: anytype) type {
                         // recursively render struct members using the known item buffer
                         var recursive_params = params;
                         recursive_params.variable_value_buf = buf[buf_start..buf_end];
-                        recursive_params.variable.data_type = member.data_type;
+                        recursive_params.variable.data_type = member_data_type.data_type_ndx;
 
+                        const member_ndx = fields.items.len;
                         try self.renderVariableValue(fields, pointers, recursive_params);
-                        const member_ndx = fields.items.len - 1;
+                        assert(fields.items.len > member_ndx);
 
                         // cache and assign the struct member's variable name
                         const member_name = self.data.target.?.strings.get(member.name) orelse types.Unknown;

--- a/src/gui/views/Primary.zig
+++ b/src/gui/views/Primary.zig
@@ -956,7 +956,7 @@ fn renderSingleExpression(
     // render the expressions identifier
     var tree_expanded = false;
     if (zui.tableNextColumn()) {
-        if (opts.to_delete != null and field_ndx == 0) {
+        if (opts.to_delete != null and opts.depth == 0) {
             const delete_label = try self.deleteWatchExpressionLabel(expr_ndx, field_ndx);
             if (zui.button(@ptrCast(delete_label), .{})) {
                 try opts.to_delete.?.append(expr_ndx);
@@ -971,7 +971,7 @@ fn renderSingleExpression(
         zui.setCursorPosX(cursor + padding);
 
         const tree_label = try fmt.allocPrint(scratch, "{s}\x00", .{expr_name});
-        if (field_ndx == 0 and expr.fields.len > 1 and field.encoding != .@"enum") {
+        if (expr.fields.len > 1 and (field.encoding == .@"struct" or field.encoding == .array)) {
             if (zui.treeNode(@ptrCast(tree_label))) tree_expanded = true;
         } else if (expr.fields[0].encoding == .array and field_ndx > 0) {
             zui.textWrapped("{s}[{d}]", .{ expr_name, field_ndx - 1 });
@@ -1055,7 +1055,7 @@ fn renderPrimitiveOrCollapsedTreePreview(
             try preview.appendSlice(scratch, "{ ");
 
             var elem_ndx: usize = 1;
-            while (elem_ndx < expr.fields.len) : (elem_ndx += 1) {
+            while (elem_ndx < arr.items.len) : (elem_ndx += 1) {
                 const elem = expr.fields[elem_ndx];
                 const val = switch (elem.encoding) {
                     .primitive => try renderWatchValue(scratch, paused, elem, .{}),

--- a/src/gui/views/Primary.zig
+++ b/src/gui/views/Primary.zig
@@ -889,6 +889,7 @@ const RenderExpressionResultOptions = struct {
     label: String,
     to_delete: ?*ArrayList(usize) = null,
     depth: usize = 0,
+    field_index_subscript: ?usize = null,
 };
 
 fn renderExpressionResultTable(
@@ -973,8 +974,8 @@ fn renderSingleExpression(
         const tree_label = try fmt.allocPrint(scratch, "{s}\x00", .{expr_name});
         if (expr.fields.len > 1 and (field.encoding == .@"struct" or field.encoding == .array)) {
             if (zui.treeNode(@ptrCast(tree_label))) tree_expanded = true;
-        } else if (expr.fields[0].encoding == .array and field_ndx > 0) {
-            zui.textWrapped("{s}[{d}]", .{ expr_name, field_ndx - 1 });
+        } else if (opts.field_index_subscript != null) {
+            zui.textWrapped("{s}[{d}]", .{ expr_name, opts.field_index_subscript.? });
         } else {
             zui.textWrapped("{s}", .{expr_name});
         }
@@ -1028,10 +1029,10 @@ fn renderPrimitiveOrCollapsedTreePreview(
     const val = switch (field.encoding) {
         .primitive => try renderWatchValue(scratch, paused, field, .{ .render_length = true }),
 
-        .@"enum" => blk: {
+        .@"enum" => |enm| blk: {
             // render the enum name and its underlying value
             const name = name: {
-                if (field.name) |n| break :name paused.strings.get(n) orelse types.Unknown;
+                if (enm.name) |n| break :name paused.strings.get(n) orelse types.Unknown;
                 break :name types.Unknown;
             };
             zui.text("{s} ", .{name});
@@ -1055,7 +1056,7 @@ fn renderPrimitiveOrCollapsedTreePreview(
             try preview.appendSlice(scratch, "{ ");
 
             var elem_ndx: usize = 1;
-            while (elem_ndx < arr.items.len) : (elem_ndx += 1) {
+            while (elem_ndx < arr.items.len + 1) : (elem_ndx += 1) {
                 const elem = expr.fields[elem_ndx];
                 const val = switch (elem.encoding) {
                     .primitive => try renderWatchValue(scratch, paused, elem, .{}),
@@ -1069,13 +1070,13 @@ fn renderPrimitiveOrCollapsedTreePreview(
                 // final element in the list, we're done
                 if (elem_ndx == expr.fields.len - 1) break;
 
+                try preview.appendSlice(scratch, ", ");
+
                 // there are more items, but we lack the space to render them
-                if (preview.items.len >= 20) { // @TODO (jrc): calculate the available space for the preview
-                    try preview.appendSlice(scratch, " ...");
+                if (preview.items.len >= 12) { // @TODO (jrc): calculate the available space for the preview
+                    try preview.appendSlice(scratch, "...");
                     break;
                 }
-
-                try preview.appendSlice(scratch, ", ");
             }
 
             try preview.appendSlice(scratch, " }");
@@ -1148,7 +1149,8 @@ fn renderExpandedTree(
             renderLength(arr.items.len);
             renderDataTypeColumn(paused, field);
 
-            for (arr.items) |item_ndx| {
+            for (arr.items, 0..) |item_ndx, ndx| {
+                recursive_opts.field_index_subscript = ndx;
                 const item = expr.fields[item_ndx.int()];
                 try self.renderSingleExpression(
                     scratch,

--- a/src/test/simulator.zig
+++ b/src/test/simulator.zig
@@ -618,7 +618,7 @@ test "sim:zigprint" {
     const exe_path = "assets/zigprint/out";
     const zigprint_main_zig_hash = try fileHash(t.allocator, "assets/zigprint/main.zig");
 
-    const expected_output_len = 871;
+    const expected_output_len = 873;
 
     // zig fmt: off
     sim.lock()
@@ -650,7 +650,7 @@ test "sim:zigprint" {
         .send_after_ticks = 1,
         .req = (proto.UpdateBreakpointRequest{ .loc = .{ .source = .{
             .file_hash = zigprint_main_zig_hash,
-            .line = types.SourceLine.from(132),
+            .line = types.SourceLine.from(145),
         }}}).req(),
     })
 
@@ -693,7 +693,7 @@ test "sim:zigprint" {
                         if (s.state.subordinate_output.len == 0) return null;
 
                         // spot check a few fields
-                        const num_locals = 54;
+                        const num_locals = 56;
                         if (checkeq(usize, 4, s.state.subordinate_output.len, "unexpected program output len") and
                             checkeq(usize, num_locals, paused.locals.len, "unexpected number of local variables") and
                             checkeq(usize, num_locals, paused.locals.len, "unexpected number of local variable expression results") and

--- a/src/test/simulator.zig
+++ b/src/test/simulator.zig
@@ -618,7 +618,7 @@ test "sim:zigprint" {
     const exe_path = "assets/zigprint/out";
     const zigprint_main_zig_hash = try fileHash(t.allocator, "assets/zigprint/main.zig");
 
-    const expected_output_len = 869;
+    const expected_output_len = 871;
 
     // zig fmt: off
     sim.lock()


### PR DESCRIPTION
Gets us a substantial portion of the way towards rendering nested data structures. Fixes several debugger-layer as well as presentation-layer issues along the way:

- Don't follow zero pointer values, just assume that it's uninitialized/garbage data and leave it alone
- Fix a bug where we're using the wrong member index in rendering struct members
- Fix rendering enum names as well as their values
- Fix rendering array index subscripts
- Adds some test cases to zigprint

Here's an example of some real-world code that's making heavy use of ArrayLists:

![image](https://github.com/user-attachments/assets/7cdcde1a-1223-48f9-9375-ea4c04077894)