### PR TITLE
Basic Support for Multithreaded Subordinates

### DIFF
--- a/assets/zigmultithread/main.zig
+++ b/assets/zigmultithread/main.zig
@@ -14,23 +14,29 @@ pub fn main() !void {
 
     {
         wg.start();
-        const thread = try Thread.spawn(.{}, sleepThread, .{ wg, 100 });
-        try thread.setName("thread100");
+        const thread = try Thread.spawn(.{}, sleepThread, .{ wg, 1 });
+        try thread.setName("thread1");
     }
 
     {
         wg.start();
-        const thread = try Thread.spawn(.{}, sleepThread, .{ wg, 200 });
-        try thread.setName("thread200");
+        const thread = try Thread.spawn(.{}, sleepThread, .{ wg, 2 });
+        try thread.setName("thread2");
+    }
+
+    {
+        wg.start();
+        const thread = try Thread.spawn(.{}, sleepThread, .{ wg, 3 });
+        try thread.setName("thread3");
     }
 
     wg.wait();
 }
 
-fn sleepThread(wg: *WaitGroup, sleep_ms: u64) void {
+fn sleepThread(wg: *WaitGroup, sleep_secs: u64) void {
     defer wg.finish();
 
-    print("sleeping for {d}ms\n", .{sleep_ms});
-    Thread.sleep(sleep_ms * std.time.ns_per_ms);
-    print("sleep for {d}ms complete\n", .{sleep_ms});
+    print("sleeping for {d}s\n", .{sleep_secs});
+    Thread.sleep(sleep_secs * std.time.ns_per_s);
+    print("sleep for {d}s complete\n", .{sleep_secs});
 }

--- a/assets/zigmultithread/main.zig
+++ b/assets/zigmultithread/main.zig
@@ -5,7 +5,6 @@ const WaitGroup = Thread.WaitGroup;
 
 pub fn main() !void {
     print("starting zigmultithread\n", .{});
-    defer print("zigmultithread done\n", .{});
 
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
     const alloc = gpa.allocator();
@@ -31,6 +30,7 @@ pub fn main() !void {
     }
 
     wg.wait();
+    print("zigmultithread done\n", .{});
 }
 
 fn sleepThread(wg: *WaitGroup, sleep_secs: u64) void {

--- a/src/debugger.zig
+++ b/src/debugger.zig
@@ -1,4 +1,6 @@
-pub const Child = @import("debugger/Child.zig");
 const debugger = @import("debugger/debugger.zig");
+
+pub const Child = @import("debugger/Child.zig");
 pub const Debugger = debugger.Debugger;
 pub const proto = @import("debugger/proto.zig");
+pub const SubordinateEvent = debugger.SubordinateEvent;

--- a/src/debugger/proto.zig
+++ b/src/debugger/proto.zig
@@ -182,15 +182,20 @@ pub const ReceivedTextOutputResponse = struct {
 
 /// Indicates that the subordinate has paused execution
 pub const SubordinateStoppedRequest = struct {
+    pub const Flags = packed struct {
+        /// If true, indicates that a subordinate thread or process with the
+        /// given PID has completed executing or otherwise exited
+        exited: bool = false,
+
+        /// Sometimes, the subordinate received signals that stop the process but
+        /// should not stop the debugger (i.e. on Linux, window resize signals)
+        should_stop_debugger: bool = true,
+    };
+
     /// The PID of the subordinate process/thread that was stopped
     pid: types.PID,
 
-    /// Whether or not the subordinate process exited
-    exited: bool,
-
-    /// Sometimes, the subordinate received signals that stop the process but
-    /// should not stop the debugger (i.e. on Linux, window resize signals)
-    should_stop_debugger: bool = true,
+    flags: Flags = .{},
 
     pub fn req(self: @This()) Request {
         return Request{ .stopped = self };

--- a/src/debugger/proto.zig
+++ b/src/debugger/proto.zig
@@ -19,6 +19,7 @@ pub const Request = union(enum) {
     quit: QuitRequest,
     set_hex_window_address: SetHexWindowAddressRequest,
     set_watch_expressions: SetWatchExpressionsRequest,
+    thread_spawned: ThreadSpawnedRequest,
 };
 
 /// Response can be any one of the various debugger command sent from the
@@ -234,5 +235,14 @@ pub const SetWatchExpressionsRequest = struct {
     pub fn deinit(self: @This(), alloc: Allocator) void {
         for (self.expressions) |e| alloc.free(e);
         alloc.free(self.expressions);
+    }
+};
+
+/// Informs the debugger that the subordinate process has spawned a new thread
+pub const ThreadSpawnedRequest = struct {
+    pid: types.PID,
+
+    pub fn req(self: @This()) Request {
+        return .{ .thread_spawned = self };
     }
 };

--- a/src/linux/Adapter.zig
+++ b/src/linux/Adapter.zig
@@ -614,16 +614,13 @@ pub fn handleEvent(self: *Self, pid: types.PID) !?debugger.SubordinateEvent {
             },
 
             SIG.TRAP | (PtraceEvent.EXEC << 8) => {
-                log.warn("EVENT: EXEC");
+                // @TODO (jrc): handle process spawn
             },
             SIG.TRAP | (PtraceEvent.EXIT << 8) => {
-                log.warn("EVENT: EXIT");
-            },
-            0, TrapEvent.TRACE => {
-                log.warn("EVENT: TRACE");
+                // @TODO (jrc): handle process exit
             },
             SIG.TRAP, SIG.TRAP | 0x80 => {
-                log.warn("EVENT: TRAP");
+                // @TODO (jrc): handle trap
             },
 
             else => {


### PR DESCRIPTION
As the title says, a very basic multithreaded subordinate is now capable of being debugged. I need to add automated tests, test with languages other than just zig, and try out some real-world programs.

Basically, this change was me finally sitting down with the ptrace/waitpid documentation and making sure that I was doing things in the way I should.

I still need to add UI elements to display the list of threads, then allow the user to toggle them on/off (like a DAW).