### PR TITLE
Preliminary Odin Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ This is a birds-eye overview of the features I'd like implemented before I'd per
   - Basic variable value rendering
   - Stack unwinding
   - etc.
-- Support for visualization of common data types in several languages (preliminary C and Zig support is already underway)
+- Support for visualization of common data types in several languages (preliminary C, Zig, and Odin support is already underway)
   - Adding at least C++ and Go even though they're very complicated languages since that's what I use for work
-  - Also planning on supporting at Rust, Odin, Crystal, and Jai
+  - Also planning on supporting at Rust, Crystal, and Jai
   - In general, we will design a system that handles transforming data in to user-friendly visualization that is flexible, extensible, and not tied to any one language
 - Support for multi-threaded programs
 - Debug tests by clicking on them, at least for programs with built-in testing solutions like Zig, Go, etc.
@@ -39,7 +39,7 @@ Other long-term features that will be implemented are:
 
 - Build as a library so other people can build other interesting things as well
   - The GUI debugger will be the first consumer of that library (in the same way [Ghostty](https://github.com/mitchellh/ghostty) is the first consumer of libghostty)
-- Many more types of Primary -specific data visualizations
+- Many more types of workload-specific data visualizations
   - For example, I work on chess engines for my day job, and it would be amazing to have a debugger that natively understands my position encoding and automatically visually renders interactive chess boards
 - Remote debugging
 - Conditional breakpoints

--- a/assets/odinprint/main.odin
+++ b/assets/odinprint/main.odin
@@ -56,6 +56,10 @@ main :: proc() {
 		13,
 		"this is the second field",
 	}
+	z := &y
+
+	aa := uintptr(k)
+	ab := rawptr(aa)
 
 	fmt.println(a)
 	fmt.println(b)
@@ -87,4 +91,8 @@ main :: proc() {
 	fmt.println(x)
 
 	fmt.println(y)
+	fmt.println(z)
+
+	fmt.println(aa)
+	fmt.println(ab)
 }

--- a/assets/odinprint/main.odin
+++ b/assets/odinprint/main.odin
@@ -63,7 +63,7 @@ main :: proc() {
 
 	fmt.println(a)
 	fmt.println(b)
-	fmt.println(c) // breakpoint here
+	fmt.println(c) // sim:odinprint stops here
 	fmt.println(d)
 	fmt.println(e)
 

--- a/assets/odinprint/main.odin
+++ b/assets/odinprint/main.odin
@@ -61,6 +61,11 @@ main :: proc() {
 	aa := uintptr(k)
 	ab := rawptr(aa)
 
+	MyEnum :: enum {First, Second, Third}
+	ac := MyEnum.First
+	ad := MyEnum.Second
+	ae := MyEnum.Third
+
 	fmt.println(a)
 	fmt.println(b)
 	fmt.println(c) // sim:odinprint stops here
@@ -95,4 +100,8 @@ main :: proc() {
 
 	fmt.println(aa)
 	fmt.println(ab)
+
+	fmt.println(ac)
+	fmt.println(ad)
+	fmt.println(ae)
 }

--- a/src/debugger/debugger.zig
+++ b/src/debugger/debugger.zig
@@ -2403,9 +2403,8 @@ fn DebuggerType(comptime AdapterType: anytype) type {
                     .data_type_name = try self.data.subordinate.?.paused.?.strings.add(data_type_name),
                     .address = res.address,
                     .name = try self.data.subordinate.?.paused.?.strings.add(var_name),
-                    .encoding = .{ .primitive = .{ .encoding = .string } },
+                    .encoding = .{ .string = .{ .len = res.len } },
                 });
-
                 return;
             }
 

--- a/src/debugger/debugger.zig
+++ b/src/debugger/debugger.zig
@@ -2262,6 +2262,7 @@ fn DebuggerType(comptime AdapterType: anytype) type {
 
             const encoder = switch (cu.language) {
                 .C => @import("encoding/C.zig").encoder(),
+                .Odin => @import("encoding/Odin.zig").encoder(),
                 .Zig => @import("encoding/Zig.zig").encoder(),
                 else => @import("encoding/Unknown.zig").encoder(),
             };

--- a/src/debugger/debugger.zig
+++ b/src/debugger/debugger.zig
@@ -2411,7 +2411,6 @@ fn DebuggerType(comptime AdapterType: anytype) type {
             // special-case: slices (known length plus an array)
             if (params.encoder.isSlice(enc_params)) {
                 const res = try params.encoder.renderSlice(enc_params);
-
                 try fields.append(params.scratch, .{
                     .data = null,
                     .data_type_name = try self.data.subordinate.?.paused.?.strings.add(data_type_name),

--- a/src/debugger/encoding/C.zig
+++ b/src/debugger/encoding/C.zig
@@ -52,7 +52,9 @@ fn renderString(
     const addr = types.Address.from(mem.readInt(u64, @ptrCast(params.val), endian));
 
     var str = ArrayListUnmanaged(u8){};
-    const max_str_len = 256;
+    var final_len: ?usize = 0;
+
+    const max_str_len = std.math.pow(usize, 2, 12);
     for (0..max_str_len) |ndx| {
         var buf = [_]u8{0};
         params.adapter.peekData(
@@ -67,7 +69,13 @@ fn renderString(
         if (buf[0] == 0) break;
 
         try str.append(params.scratch, buf[0]);
-        if (ndx == max_str_len - 1) try str.appendSlice(params.scratch, "...");
+        final_len.? += 1;
+
+        if (ndx == max_str_len - 1) {
+            try str.appendSlice(params.scratch, "...");
+            final_len = null; // length unknown
+            break;
+        }
 
         if (len > 0 and ndx > len) break;
     }
@@ -75,5 +83,6 @@ fn renderString(
     return .{
         .address = addr,
         .str = try str.toOwnedSlice(params.scratch),
+        .len = final_len,
     };
 }

--- a/src/debugger/encoding/C.zig
+++ b/src/debugger/encoding/C.zig
@@ -45,7 +45,7 @@ fn renderSlice(_: *const encoding.Params) encoding.EncodeVariableError!encoding.
 }
 
 /// Read C-style strings one byte at a time until we encounter a null terminator
-fn renderString(
+pub fn renderString(
     params: *const encoding.Params,
     len: u64,
 ) encoding.EncodeVariableError!encoding.RenderStringResult {

--- a/src/debugger/encoding/Odin.zig
+++ b/src/debugger/encoding/Odin.zig
@@ -1,0 +1,209 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const Allocator = std.mem.Allocator;
+const ArrayListUnmanaged = std.ArrayListUnmanaged;
+const fmt = std.fmt;
+const math = std.math;
+const mem = std.mem;
+
+const encoding = @import("encoding.zig");
+const logging = @import("../../logging.zig");
+const strings = @import("../../strings.zig");
+const String = strings.String;
+const types = @import("../../types.zig");
+
+const log = logging.Logger.init(logging.Region.Debugger);
+
+const Self = @This();
+
+const endian = builtin.cpu.arch.endian();
+
+pub fn encoder() encoding.Encoding {
+    return encoding.Encoding{
+        .isOpaquePointer = isOpaquePointer,
+        .isString = isString,
+        .renderString = renderString,
+        .isSlice = isSlice,
+        .renderSlice = renderSlice,
+    };
+}
+
+fn isOpaquePointer(params: *const encoding.Params) bool {
+    return strings.eql(params.data_type_name, "rawptr");
+}
+
+fn isString(params: *const encoding.Params) ?u64 {
+    _ = params;
+
+    // const name = params.data_type_name;
+
+    // // string slices
+    // if (params.data_type.form == .@"struct" and strings.eql(params.data_type_name, "[]u8")) {
+    //     if (readUsizeStructMember(params, "len") catch null) |len| return len.data;
+    //     return null;
+    // }
+
+    // // string literals (i.e. *[13:0]u8)
+    // if (params.data_type.form == .pointer and
+    //     mem.startsWith(u8, name, "*[") and mem.endsWith(u8, name, ":0]u8"))
+    // {
+    //     var num_str = mem.trimLeft(u8, name, "*[");
+    //     num_str = mem.trimRight(u8, num_str, ":0]u8");
+    //     return fmt.parseInt(u64, num_str, 10) catch |err| {
+    //         log.warnf("unable to parse zig string length: {!}", .{err});
+    //         return 0;
+    //     };
+    // }
+
+    return null;
+}
+
+/// Read Zig-style strings, which are a byte slice whose length we determine from the type name
+fn renderString(
+    params: *const encoding.Params,
+    len: u64,
+) encoding.EncodeVariableError!encoding.RenderStringResult {
+    _ = params;
+    _ = len;
+
+    unreachable;
+
+    // const addr = types.Address.from(mem.readInt(u64, @ptrCast(params.val), endian));
+
+    // var str = ArrayListUnmanaged(u8){};
+    // const max_str_len = math.pow(usize, 2, 12);
+    // for (0..max_str_len) |ndx| {
+    //     var buf = [_]u8{0};
+    //     params.adapter.peekData(
+    //         params.pid,
+    //         params.load_addr,
+    //         addr.addInt(ndx),
+    //         &buf,
+    //     ) catch {
+    //         return error.ReadDataError;
+    //     };
+
+    //     if (buf[0] == 0) break;
+
+    //     try str.append(params.scratch, buf[0]);
+    //     if (ndx == max_str_len - 1) try str.appendSlice(params.scratch, "...");
+
+    //     if (len > 0 and ndx > len) break;
+    // }
+
+    // return .{
+    //     .address = addr,
+    //     .str = try str.toOwnedSlice(params.scratch),
+    // };
+}
+
+// fn memberNameIs(params: *const encoding.Params, name: strings.Hash, comptime expected: String) bool {
+//     const name_str = params.target_strings.get(name) orelse return false;
+//     return strings.eql(name_str, expected);
+// }
+
+fn isSlice(params: *const encoding.Params) bool {
+    _ = params;
+    return false;
+
+    // return switch (params.base_data_type.form) {
+    //     .@"struct" => |strct| strct.members.len == 2 and
+    //         memberNameIs(params, strct.members[0].name, "ptr") and
+    //         memberNameIs(params, strct.members[1].name, "len"),
+    //     else => false,
+    // };
+}
+
+// const UsizeStructMemberResult = struct {
+//     data: usize,
+//     data_type: types.TypeNdx,
+// };
+
+// fn readUsizeStructMember(
+//     params: *const encoding.Params,
+//     comptime name: String,
+// ) encoding.EncodeVariableError!UsizeStructMemberResult {
+//     var data_type: ?types.TypeNdx = null;
+//     const member_offset_bytes = blk: {
+//         for (params.data_type.form.@"struct".members) |m| {
+//             const name_str = params.target_strings.get(m.name) orelse continue;
+//             data_type = m.data_type;
+//             if (strings.eql(name, name_str)) break :blk m.offset_bytes;
+//         }
+
+//         log.warn("slice struct does not contain a member named " ++ name);
+//         return error.ReadDataError;
+//     };
+
+//     const start = member_offset_bytes;
+//     const end = start + @sizeOf(usize);
+//     const data = mem.readInt(usize, @ptrCast(params.val[start..end]), endian);
+
+//     return .{
+//         .data = data,
+//         .data_type = data_type.?,
+//     };
+// }
+
+fn renderSlice(params: *const encoding.Params) encoding.EncodeVariableError!encoding.RenderSliceResult {
+    _ = params;
+
+    unreachable;
+
+    // // read the address of the buffer and its length
+    // const ptr = try readUsizeStructMember(params, "ptr");
+    // const addr = types.Address.from(ptr.data);
+    // const len = (try readUsizeStructMember(params, "len")).data;
+
+    // // find the number of bytes taken by one element in the buffer
+    // const member_size_bytes = blk: {
+    //     for (params.data_type.form.@"struct".members) |m| {
+    //         const name_str = params.target_strings.get(m.name) orelse continue;
+    //         if (strings.eql("ptr", name_str)) {
+    //             var base_data_type = params.cu.data_types[m.data_type.int()];
+    //             while (base_data_type.form == .pointer) {
+    //                 if (base_data_type.form.pointer.data_type) |ptr_type| {
+    //                     base_data_type = params.cu.data_types[ptr_type.int()];
+    //                     continue;
+    //                 }
+    //                 break;
+    //             }
+
+    //             break :blk base_data_type.size_bytes;
+    //         }
+    //     }
+
+    //     log.warn("slice struct does not contain a member named ptr");
+    //     return error.ReadDataError;
+    // };
+
+    // // @TODO (jrc): allow the user to configure the max preview length in their settings, or accept this as a
+    // // parameter on the render expression, i.e. `myslice | len=1000` or similar
+    // const preview_len = @min(len, 100);
+
+    // const full_buf = try params.scratch.alloc(u8, preview_len * member_size_bytes);
+    // params.adapter.peekData(params.pid, params.load_addr, addr, full_buf) catch {
+    //     return error.ReadDataError;
+    // };
+
+    // var item_bufs = try params.scratch.alloc(String, preview_len);
+    // for (0..preview_len) |ndx| {
+    //     const start = ndx * member_size_bytes;
+    //     const end = start + member_size_bytes;
+    //     item_bufs[ndx] = full_buf[start..end];
+    // }
+
+    // // dereference the pointer (i.e. []u32 -> *u32 -> u32)
+    // const ptr_t = params.cu.data_types[ptr.data_type.int()];
+    // const ptr_data_type = switch (ptr_t.form) {
+    //     .pointer => |p| p.data_type,
+    //     else => return error.InvalidDataType,
+    // };
+
+    // return encoding.RenderSliceResult{
+    //     .address = addr,
+    //     .len = len,
+    //     .item_data_type = ptr_data_type,
+    //     .item_bufs = item_bufs,
+    // };
+}

--- a/src/debugger/encoding/Odin.zig
+++ b/src/debugger/encoding/Odin.zig
@@ -1,23 +1,16 @@
 const std = @import("std");
-const builtin = @import("builtin");
 const Allocator = std.mem.Allocator;
 const ArrayListUnmanaged = std.ArrayListUnmanaged;
-const fmt = std.fmt;
-const math = std.math;
-const mem = std.mem;
 
 const C = @import("C.zig");
 const encoding = @import("encoding.zig");
 const logging = @import("../../logging.zig");
 const strings = @import("../../strings.zig");
 const String = strings.String;
-const types = @import("../../types.zig");
 
 const log = logging.Logger.init(logging.Region.Debugger);
 
 const Self = @This();
-
-const endian = builtin.cpu.arch.endian();
 
 pub fn encoder() encoding.Encoding {
     return encoding.Encoding{
@@ -39,6 +32,15 @@ fn isString(params: *const encoding.Params) ?u64 {
         return 0;
     }
 
+    // string slices
+    if (params.data_type.form == .@"struct" and strings.eql(params.data_type_name, "string")) {
+        const res = encoding.readUsizeStructMember(params, "len") catch |err| {
+            log.errf("unable to read odin string length: {!}", .{err});
+            return null;
+        };
+        return res.data;
+    }
+
     return null;
 }
 
@@ -50,113 +52,15 @@ fn renderString(
     return try C.renderString(params, len);
 }
 
-// fn memberNameIs(params: *const encoding.Params, name: strings.Hash, comptime expected: String) bool {
-//     const name_str = params.target_strings.get(name) orelse return false;
-//     return strings.eql(name_str, expected);
-// }
-
 fn isSlice(params: *const encoding.Params) bool {
-    _ = params;
-    return false;
-
-    // return switch (params.base_data_type.form) {
-    //     .@"struct" => |strct| strct.members.len == 2 and
-    //         memberNameIs(params, strct.members[0].name, "ptr") and
-    //         memberNameIs(params, strct.members[1].name, "len"),
-    //     else => false,
-    // };
+    return switch (params.data_type.form) {
+        .@"struct" => |strct| strct.members.len == 2 and
+            encoding.memberNameIs(params, strct.members[0].name, "data") and
+            encoding.memberNameIs(params, strct.members[1].name, "len"),
+        else => false,
+    };
 }
 
-// const UsizeStructMemberResult = struct {
-//     data: usize,
-//     data_type: types.TypeNdx,
-// };
-
-// fn readUsizeStructMember(
-//     params: *const encoding.Params,
-//     comptime name: String,
-// ) encoding.EncodeVariableError!UsizeStructMemberResult {
-//     var data_type: ?types.TypeNdx = null;
-//     const member_offset_bytes = blk: {
-//         for (params.data_type.form.@"struct".members) |m| {
-//             const name_str = params.target_strings.get(m.name) orelse continue;
-//             data_type = m.data_type;
-//             if (strings.eql(name, name_str)) break :blk m.offset_bytes;
-//         }
-
-//         log.warn("slice struct does not contain a member named " ++ name);
-//         return error.ReadDataError;
-//     };
-
-//     const start = member_offset_bytes;
-//     const end = start + @sizeOf(usize);
-//     const data = mem.readInt(usize, @ptrCast(params.val[start..end]), endian);
-
-//     return .{
-//         .data = data,
-//         .data_type = data_type.?,
-//     };
-// }
-
 fn renderSlice(params: *const encoding.Params) encoding.EncodeVariableError!encoding.RenderSliceResult {
-    _ = params;
-
-    unreachable;
-
-    // // read the address of the buffer and its length
-    // const ptr = try readUsizeStructMember(params, "ptr");
-    // const addr = types.Address.from(ptr.data);
-    // const len = (try readUsizeStructMember(params, "len")).data;
-
-    // // find the number of bytes taken by one element in the buffer
-    // const member_size_bytes = blk: {
-    //     for (params.data_type.form.@"struct".members) |m| {
-    //         const name_str = params.target_strings.get(m.name) orelse continue;
-    //         if (strings.eql("ptr", name_str)) {
-    //             var base_data_type = params.cu.data_types[m.data_type.int()];
-    //             while (base_data_type.form == .pointer) {
-    //                 if (base_data_type.form.pointer.data_type) |ptr_type| {
-    //                     base_data_type = params.cu.data_types[ptr_type.int()];
-    //                     continue;
-    //                 }
-    //                 break;
-    //             }
-
-    //             break :blk base_data_type.size_bytes;
-    //         }
-    //     }
-
-    //     log.warn("slice struct does not contain a member named ptr");
-    //     return error.ReadDataError;
-    // };
-
-    // // @TODO (jrc): allow the user to configure the max preview length in their settings, or accept this as a
-    // // parameter on the render expression, i.e. `myslice | len=1000` or similar
-    // const preview_len = @min(len, 100);
-
-    // const full_buf = try params.scratch.alloc(u8, preview_len * member_size_bytes);
-    // params.adapter.peekData(params.pid, params.load_addr, addr, full_buf) catch {
-    //     return error.ReadDataError;
-    // };
-
-    // var item_bufs = try params.scratch.alloc(String, preview_len);
-    // for (0..preview_len) |ndx| {
-    //     const start = ndx * member_size_bytes;
-    //     const end = start + member_size_bytes;
-    //     item_bufs[ndx] = full_buf[start..end];
-    // }
-
-    // // dereference the pointer (i.e. []u32 -> *u32 -> u32)
-    // const ptr_t = params.cu.data_types[ptr.data_type.int()];
-    // const ptr_data_type = switch (ptr_t.form) {
-    //     .pointer => |p| p.data_type,
-    //     else => return error.InvalidDataType,
-    // };
-
-    // return encoding.RenderSliceResult{
-    //     .address = addr,
-    //     .len = len,
-    //     .item_data_type = ptr_data_type,
-    //     .item_bufs = item_bufs,
-    // };
+    return encoding.renderSlice("data", "len", params);
 }

--- a/src/debugger/encoding/Zig.zig
+++ b/src/debugger/encoding/Zig.zig
@@ -1,5 +1,4 @@
 const std = @import("std");
-const builtin = @import("builtin");
 const Allocator = std.mem.Allocator;
 const ArrayListUnmanaged = std.ArrayListUnmanaged;
 const fmt = std.fmt;
@@ -15,8 +14,6 @@ const types = @import("../../types.zig");
 const log = logging.Logger.init(logging.Region.Debugger);
 
 const Self = @This();
-
-const endian = builtin.cpu.arch.endian();
 
 pub fn encoder() encoding.Encoding {
     return encoding.Encoding{
@@ -37,7 +34,7 @@ fn isString(params: *const encoding.Params) ?u64 {
 
     // string slices
     if (params.data_type.form == .@"struct" and strings.eql(params.data_type_name, "[]u8")) {
-        if (readUsizeStructMember(params, "len") catch null) |len| return len.data;
+        if (encoding.readUsizeStructMember(params, "len") catch null) |len| return len.data;
         return null;
     }
 
@@ -61,7 +58,7 @@ fn renderString(
     params: *const encoding.Params,
     len: u64,
 ) encoding.EncodeVariableError!encoding.RenderStringResult {
-    const addr = types.Address.from(mem.readInt(u64, @ptrCast(params.val), endian));
+    const addr = types.Address.from(mem.readInt(u64, @ptrCast(params.val), encoding.endian));
 
     var str = ArrayListUnmanaged(u8){};
     const max_str_len = math.pow(usize, 2, 12);
@@ -91,106 +88,15 @@ fn renderString(
     };
 }
 
-fn memberNameIs(params: *const encoding.Params, name: strings.Hash, comptime expected: String) bool {
-    const name_str = params.target_strings.get(name) orelse return false;
-    return strings.eql(name_str, expected);
-}
-
 fn isSlice(params: *const encoding.Params) bool {
-    return switch (params.base_data_type.form) {
+    return switch (params.data_type.form) {
         .@"struct" => |strct| strct.members.len == 2 and
-            memberNameIs(params, strct.members[0].name, "ptr") and
-            memberNameIs(params, strct.members[1].name, "len"),
+            encoding.memberNameIs(params, strct.members[0].name, "ptr") and
+            encoding.memberNameIs(params, strct.members[1].name, "len"),
         else => false,
     };
 }
 
-const UsizeStructMemberResult = struct {
-    data: usize,
-    data_type: types.TypeNdx,
-};
-
-fn readUsizeStructMember(
-    params: *const encoding.Params,
-    comptime name: String,
-) encoding.EncodeVariableError!UsizeStructMemberResult {
-    var data_type: ?types.TypeNdx = null;
-    const member_offset_bytes = blk: {
-        for (params.data_type.form.@"struct".members) |m| {
-            const name_str = params.target_strings.get(m.name) orelse continue;
-            data_type = m.data_type;
-            if (strings.eql(name, name_str)) break :blk m.offset_bytes;
-        }
-
-        log.warn("slice struct does not contain a member named " ++ name);
-        return error.ReadDataError;
-    };
-
-    const start = member_offset_bytes;
-    const end = start + @sizeOf(usize);
-    const data = mem.readInt(usize, @ptrCast(params.val[start..end]), endian);
-
-    return .{
-        .data = data,
-        .data_type = data_type.?,
-    };
-}
-
 fn renderSlice(params: *const encoding.Params) encoding.EncodeVariableError!encoding.RenderSliceResult {
-    // read the address of the buffer and its length
-    const ptr = try readUsizeStructMember(params, "ptr");
-    const addr = types.Address.from(ptr.data);
-    const len = (try readUsizeStructMember(params, "len")).data;
-
-    // find the number of bytes taken by one element in the buffer
-    const member_size_bytes = blk: {
-        for (params.data_type.form.@"struct".members) |m| {
-            const name_str = params.target_strings.get(m.name) orelse continue;
-            if (strings.eql("ptr", name_str)) {
-                var base_data_type = params.cu.data_types[m.data_type.int()];
-                while (base_data_type.form == .pointer) {
-                    if (base_data_type.form.pointer.data_type) |ptr_type| {
-                        base_data_type = params.cu.data_types[ptr_type.int()];
-                        continue;
-                    }
-                    break;
-                }
-
-                break :blk base_data_type.size_bytes;
-            }
-        }
-
-        log.warn("slice struct does not contain a member named ptr");
-        return error.ReadDataError;
-    };
-
-    // @TODO (jrc): allow the user to configure the max preview length in their settings, or accept this as a
-    // parameter on the render expression, i.e. `myslice | len=1000` or similar
-    const preview_len = @min(len, 100);
-
-    const full_buf = try params.scratch.alloc(u8, preview_len * member_size_bytes);
-    params.adapter.peekData(params.pid, params.load_addr, addr, full_buf) catch {
-        return error.ReadDataError;
-    };
-
-    var item_bufs = try params.scratch.alloc(String, preview_len);
-    for (0..preview_len) |ndx| {
-        const start = ndx * member_size_bytes;
-        const end = start + member_size_bytes;
-        item_bufs[ndx] = full_buf[start..end];
-    }
-
-    // dereference the pointer (i.e. []u32 -> *u32 -> u32)
-    const ptr_t = params.cu.data_types[ptr.data_type.int()];
-    const ptr_data_type = switch (ptr_t.form) {
-        .pointer => |p| p.data_type,
-        else => return error.InvalidDataType,
-    };
-
-    return encoding.RenderSliceResult{
-        .address = addr,
-        .len = len,
-        .item_data_type = ptr_data_type,
-        .item_bufs = item_bufs,
-    };
+    return encoding.renderSlice("ptr", "len", params);
 }

--- a/src/debugger/encoding/Zig.zig
+++ b/src/debugger/encoding/Zig.zig
@@ -87,6 +87,7 @@ fn renderString(
     return .{
         .address = addr,
         .str = try str.toOwnedSlice(params.scratch),
+        .len = len,
     };
 }
 

--- a/src/debugger/encoding/encoding.zig
+++ b/src/debugger/encoding/encoding.zig
@@ -55,6 +55,10 @@ pub const RenderStringResult = struct {
 
     /// A preview of the string (this may be shorter than the actual string)
     str: String,
+
+    /// The final calculated size of the full string (not just the preview). This is null in
+    /// the case of very long null-terminated strings.
+    len: ?usize,
 };
 
 pub const RenderSliceResult = struct {

--- a/src/debugger/encoding/encoding.zig
+++ b/src/debugger/encoding/encoding.zig
@@ -1,10 +1,17 @@
 const std = @import("std");
-const Allocator = std.mem.Allocator;
+const builtin = @import("builtin");
+const Allocator = mem.Allocator;
+const mem = std.mem;
 
 const Adapter = @import("../debugger.zig").Adapter;
+const logging = @import("../../logging.zig");
 const strings = @import("../../strings.zig");
 const String = strings.String;
 const types = @import("../../types.zig");
+
+const log = logging.Logger.init(logging.Region.Debugger);
+
+pub const endian = builtin.cpu.arch.endian();
 
 pub const Params = struct {
     /// Must be a scratch arena allocator. Caller owns all returned memory.
@@ -75,3 +82,117 @@ pub const RenderSliceResult = struct {
     /// A preview of the slice items (this may be shorter than the actual slice)
     item_bufs: []String,
 };
+
+pub const UsizeStructMemberResult = struct {
+    data: usize,
+    data_type: types.TypeNdx,
+};
+
+pub fn readUsizeStructMember(
+    params: *const Params,
+    comptime name: String,
+) EncodeVariableError!UsizeStructMemberResult {
+    var data_type: ?types.TypeNdx = null;
+    const member_offset_bytes = blk: {
+        for (params.data_type.form.@"struct".members) |m| {
+            const name_str = params.target_strings.get(m.name) orelse continue;
+            data_type = m.data_type;
+            if (strings.eql(name, name_str)) break :blk m.offset_bytes;
+        }
+
+        log.warn("slice struct does not contain a member named " ++ name);
+        return error.ReadDataError;
+    };
+
+    const start = member_offset_bytes;
+    const end = start + @sizeOf(usize);
+    const data = mem.readInt(usize, @ptrCast(params.val[start..end]), endian);
+
+    return .{
+        .data = data,
+        .data_type = data_type.?,
+    };
+}
+
+pub fn memberNameIs(params: *const Params, name: strings.Hash, comptime expected: String) bool {
+    const name_str = params.target_strings.get(name) orelse return false;
+    return strings.eql(name_str, expected);
+}
+
+pub fn renderSlice(
+    comptime data_name: String,
+    comptime len_name: String,
+    params: *const Params,
+) EncodeVariableError!RenderSliceResult {
+    // read the address of the buffer and its length
+    const ptr = try readUsizeStructMember(params, data_name);
+    const addr = types.Address.from(ptr.data);
+    const len = (try readUsizeStructMember(params, len_name)).data;
+
+    // find the number of bytes taken by one element in the buffer
+    const member_size_bytes = blk: {
+        for (params.data_type.form.@"struct".members) |m| {
+            const name_str = params.target_strings.get(m.name) orelse continue;
+            if (strings.eql(data_name, name_str)) {
+                var base_data_type = params.cu.data_types[m.data_type.int()];
+
+                // follow pointers and typedefs to their base type
+                var done = false;
+                while (!done) {
+                    switch (base_data_type.form) {
+                        .pointer => |p| {
+                            if (p.data_type) |ptr_type|
+                                base_data_type = params.cu.data_types[ptr_type.int()];
+                        },
+
+                        .typedef => |td| {
+                            if (td.data_type) |td_type|
+                                base_data_type = params.cu.data_types[td_type.int()];
+                        },
+
+                        else => done = true,
+                    }
+                }
+
+                while (base_data_type.form == .pointer) {
+                    break;
+                }
+
+                break :blk base_data_type.size_bytes;
+            }
+        }
+
+        log.warn("slice struct does not contain a member named " ++ data_name);
+        return error.ReadDataError;
+    };
+
+    // @TODO (jrc): allow the user to configure the max preview length in their settings, or accept this as a
+    // parameter on the render expression, i.e. `myslice | len=1000` or similar
+    const preview_len = @min(len, 100);
+
+    const full_buf = try params.scratch.alloc(u8, preview_len * member_size_bytes);
+    params.adapter.peekData(params.pid, params.load_addr, addr, full_buf) catch {
+        return error.ReadDataError;
+    };
+
+    var item_bufs = try params.scratch.alloc(String, preview_len);
+    for (0..preview_len) |ndx| {
+        const start = ndx * member_size_bytes;
+        const end = start + member_size_bytes;
+        item_bufs[ndx] = full_buf[start..end];
+    }
+
+    // dereference the pointer (i.e. []u32 -> *u32 -> u32)
+    const ptr_t = params.cu.data_types[ptr.data_type.int()];
+    const ptr_data_type = switch (ptr_t.form) {
+        .pointer => |p| p.data_type,
+        else => return error.InvalidDataType,
+    };
+
+    return RenderSliceResult{
+        .address = addr,
+        .len = len,
+        .item_data_type = ptr_data_type,
+        .item_bufs = item_bufs,
+    };
+}

--- a/src/gui/views/Primary.zig
+++ b/src/gui/views/Primary.zig
@@ -1342,8 +1342,7 @@ fn renderLength(len: usize) void {
 }
 
 fn renderWatchBoolean(scratch: Allocator, buf: []const u8) Allocator.Error![]const u8 {
-    assert(buf.len == 1);
-
+    // @NOTE (jrc): Odin has bools of varying lengths
     const res = if (buf.len > 0 and buf[0] != 0) "true" else "false";
     return try strings.clone(scratch, res);
 }

--- a/src/test/simulator.zig
+++ b/src/test/simulator.zig
@@ -1039,12 +1039,8 @@ fn checkNestedZigStructMembers(paused: types.PauseData, res: types.ExpressionRes
             return false;
         };
 
-        if (member.encoding != .primitive) {
-            log.errf("\"ap.field_b\" was not a primitive, got {s}", .{@tagName(member.encoding)});
-            return false;
-        }
-        if (member.encoding.primitive.encoding != .string) {
-            log.errf("\"ap.field_b\" was not a string, got {s}", .{@tagName(member.encoding.primitive.encoding)});
+        if (member.encoding != .string) {
+            log.errf("\"ap.field_b\" was not a string, got {s}", .{@tagName(member.encoding)});
             return false;
         }
 


### PR DESCRIPTION
Tested with the odin version in the dockerfile (2025-01 at time of writing).

Refactors a lot of code that was previously c-or-zig-specific to be shared between c, zig, and odin data encoding.

There are more built-in odin types that need work (i.e. maps) but those will come later as I have no space for them at present in the core of the debugger. This will provide a good jumping off point to think about them more.

Here's a screenshot of it in action. Notice that strings and slices are correctly encoded for instance:

![image](https://github.com/user-attachments/assets/4370acdd-ea02-4882-a2dc-009f4db8252d)
