### PR TITLE
Add Preliminary C3 Support, Fix some Load Addr Bugs

### DIFF
--- a/.woodpecker/ci.yaml
+++ b/.woodpecker/ci.yaml
@@ -4,26 +4,26 @@ when:
 
 steps:
   - name: Build Assets
-    image: jcalabro/uscope-dev:2025-02-14
+    image: jcalabro/uscope-dev:2025-02-20
     commands: |
       pushd assets > /dev/null
       ./build.sh CI
       popd > /dev/null
 
   - name: Build and Test (tsan)
-    image: jcalabro/uscope-dev:2025-02-14
+    image: jcalabro/uscope-dev:2025-02-20
     commands: |
       zigup run $(cat zig_version.txt) build --summary all -freference-trace -Drace -Dci -Dllvm
       ./zig-out/bin/uscope-tests
 
   - name: Build and Test (valgrind)
-    image: jcalabro/uscope-dev:2025-02-14
+    image: jcalabro/uscope-dev:2025-02-20
     commands: |
       zigup run $(cat zig_version.txt) build --summary all -freference-trace -Doptimize=ReleaseSafe -Dci -Dllvm -Dvalgrind
       valgrind --leak-check=full --error-exitcode=1 ./zig-out/bin/uscope-tests
 
   - name: Build and Test (release)
-    image: jcalabro/uscope-dev:2025-02-14
+    image: jcalabro/uscope-dev:2025-02-20
     commands: |
       zigup run $(cat zig_version.txt) build --summary all -freference-trace -Doptimize=ReleaseSafe -Dci -Dllvm
       ./zig-out/bin/uscope-tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,11 @@ RUN dnf install -y \
         golang-1.23.2-2.fc41 \
         rust-1.81.0-6.fc41
 
+ENV PATH="${PATH}:/usr/local/bin/c3"
+RUN curl -L -o c3.tar.gz https://github.com/c3lang/c3c/releases/download/latest/c3-linux.tar.gz && \
+    tar xzf c3.tar.gz && \
+    mv c3 /usr/local/bin
+
 RUN curl -L -o odin.zip https://github.com/odin-lang/Odin/releases/download/dev-2025-01/odin-ubuntu-amd64-dev-2025-01.zip && \
     unzip odin.zip && rm -f odin.zip && \
     tar -xzf dist.tar.gz && rm -rf dist.tar.gz && \

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This is a birds-eye overview of the features I'd like implemented before I'd per
   - Basic variable value rendering
   - Stack unwinding
   - etc.
-- Support for visualization of common data types in several languages (preliminary C, Zig, and Odin support is already underway)
+- Support for visualization of common data types in several languages (preliminary C, Zig, Odin, and C3 support is already underway)
   - Adding at least C++ and Go even though they're very complicated languages since that's what I use for work
   - Also planning on supporting at Rust, Crystal, and Jai
   - In general, we will design a system that handles transforming data in to user-friendly visualization that is flexible, extensible, and not tied to any one language

--- a/assets/c3print/build.sh
+++ b/assets/c3print/build.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 set -x
-c3c compile -g -o out main.c3
+c3c compile -g -O0 -o out main.c3

--- a/assets/c3print/build.sh
+++ b/assets/c3print/build.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+set -x
+c3c compile -g -o out main.c3

--- a/assets/c3print/clean.sh
+++ b/assets/c3print/clean.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+set -x
+rm -f out

--- a/assets/c3print/main.c3
+++ b/assets/c3print/main.c3
@@ -1,0 +1,86 @@
+import std::io;
+
+struct MyStruct
+{
+    char field_a;
+    String field_b;
+}
+
+enum MyEnum : int
+{
+	FIRST,
+	SECOND,
+	THIRD
+}
+
+fn void main()
+{
+	bool a = true;
+	bool b = false;
+
+	ichar   c = 1;
+	short   d = 2;
+	int     e = 3;
+	long    f = 4;
+	int128  g = 5;
+	iptr    h = 6;
+	isz     i = 7;
+	char    j = 8;
+	ushort  k = 9;
+	uint    l = 11;
+	ulong   m = 12;
+	uint128 n = 13;
+	uptr    o = 14;
+	usz     p = 15;
+
+	float q = 16.1;
+	double r = 17.2;
+
+	String s = "Hello, world!";
+	String* t = &s;
+	void* u = t;
+
+	int[*] v = { 11, 22, 33 }; // array
+	int[]  w = &v;          // slice
+
+	MyStruct x;
+    x.field_a = 18;
+    x.field_b = "this is the second field";
+
+	MyEnum y = MyEnum.FIRST;
+	MyEnum z = MyEnum.SECOND;
+	MyEnum aa = MyEnum.THIRD;
+
+    io::printn(a);
+    io::printn(b);
+
+	io::printn(c); // sim:c3print stops here
+	io::printn(d);
+	io::printn(e);
+	io::printn(f);
+	io::printn(g);
+	io::printn(h);
+	io::printn(i);
+	io::printn(j);
+	io::printn(k);
+	io::printn(l);
+	io::printn(m);
+	io::printn(n);
+	io::printn(o);
+	io::printn(p);
+
+	io::printn(q);
+	io::printn(r);
+
+	io::printn(s);
+	io::printn(*t);
+
+	io::printn(v);
+	io::printn(w);
+
+	io::printn(x);
+
+	io::printn(y);
+	io::printn(z);
+	io::printn(aa);
+}

--- a/assets/c3print/main.c3
+++ b/assets/c3print/main.c3
@@ -40,8 +40,8 @@ fn void main()
 	String* t = &s;
 	void* u = t;
 
-	int[*] v = { 11, 22, 33 }; // array
-	int[]  w = &v;          // slice
+	int[*] v = { 11, 12, 13 }; // array
+	int[]  w = &v;             // slice
 
 	MyStruct x;
     x.field_a = 18;
@@ -49,7 +49,7 @@ fn void main()
 
 	MyEnum y = MyEnum.FIRST;
 	MyEnum z = MyEnum.SECOND;
-	MyEnum aa = MyEnum.THIRD; // sim:c3print stops here
+	MyEnum aa = MyEnum.THIRD; // sim:c3print stops here because all the prints are inlined
 
     io::printn(a);
     io::printn(b);

--- a/assets/c3print/main.c3
+++ b/assets/c3print/main.c3
@@ -49,12 +49,12 @@ fn void main()
 
 	MyEnum y = MyEnum.FIRST;
 	MyEnum z = MyEnum.SECOND;
-	MyEnum aa = MyEnum.THIRD;
+	MyEnum aa = MyEnum.THIRD; // sim:c3print stops here
 
     io::printn(a);
     io::printn(b);
 
-	io::printn(c); // sim:c3print stops here
+	io::printn(c);
 	io::printn(d);
 	io::printn(e);
 	io::printn(f);

--- a/src/debugger/encoding/C.zig
+++ b/src/debugger/encoding/C.zig
@@ -59,7 +59,7 @@ pub fn renderString(
         var buf = [_]u8{0};
         params.adapter.peekData(
             params.pid,
-            params.load_addr,
+            types.Address.from(0),
             addr.addInt(ndx),
             &buf,
         ) catch {

--- a/src/debugger/encoding/C3.zig
+++ b/src/debugger/encoding/C3.zig
@@ -1,0 +1,72 @@
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const ArrayListUnmanaged = std.ArrayListUnmanaged;
+
+const C = @import("C.zig");
+const encoding = @import("encoding.zig");
+const logging = @import("../../logging.zig");
+const strings = @import("../../strings.zig");
+const String = strings.String;
+
+const log = logging.Logger.init(logging.Region.Debugger);
+
+const Self = @This();
+
+pub fn encoder() encoding.Encoding {
+    return encoding.Encoding{
+        .isOpaquePointer = isOpaquePointer,
+        .isString = isString,
+        .renderString = renderString,
+        .isSlice = isSlice,
+        .renderSlice = renderSlice,
+    };
+}
+
+fn isOpaquePointer(params: *const encoding.Params) bool {
+    return strings.eql(params.data_type_name, "void*");
+}
+
+fn isString(params: *const encoding.Params) ?u64 {
+    // string slices
+    if (params.data_type.form == .@"struct" and strings.eql(params.data_type_name, "char[]")) {
+        const res = encoding.readUsizeStructMember(params, "len") catch |err| {
+            log.errf("unable to read c3 string length: {!}", .{err});
+            return null;
+        };
+        return res.data;
+    }
+
+    return null;
+}
+
+/// Read C-style null terminated strings
+fn renderString(
+    params: *const encoding.Params,
+    len: u64,
+) encoding.EncodeVariableError!encoding.RenderStringResult {
+    const res = try encoding.renderSlice("ptr", "len", params);
+
+    const buf = try params.scratch.alloc(u8, res.item_bufs.len);
+    for (res.item_bufs, 0..) |item, ndx| {
+        buf[ndx] = item[0];
+    }
+
+    return encoding.RenderStringResult{
+        .address = res.address,
+        .str = buf,
+        .len = len,
+    };
+}
+
+fn isSlice(params: *const encoding.Params) bool {
+    return switch (params.data_type.form) {
+        .@"struct" => |strct| strct.members.len == 2 and
+            encoding.memberNameIs(params, strct.members[0].name, "ptr") and
+            encoding.memberNameIs(params, strct.members[1].name, "len"),
+        else => false,
+    };
+}
+
+fn renderSlice(params: *const encoding.Params) encoding.EncodeVariableError!encoding.RenderSliceResult {
+    return encoding.renderSlice("ptr", "len", params);
+}

--- a/src/debugger/encoding/Zig.zig
+++ b/src/debugger/encoding/Zig.zig
@@ -66,7 +66,7 @@ fn renderString(
         var buf = [_]u8{0};
         params.adapter.peekData(
             params.pid,
-            params.load_addr,
+            types.Address.from(0),
             addr.addInt(ndx),
             &buf,
         ) catch {

--- a/src/debugger/encoding/encoding.zig
+++ b/src/debugger/encoding/encoding.zig
@@ -19,7 +19,6 @@ pub const Params = struct {
 
     adapter: *Adapter,
     pid: types.PID,
-    load_addr: types.Address,
     cu: *const types.CompileUnit,
     target_strings: *strings.Cache,
 
@@ -171,7 +170,7 @@ pub fn renderSlice(
     const preview_len = @min(len, 100);
 
     const full_buf = try params.scratch.alloc(u8, preview_len * member_size_bytes);
-    params.adapter.peekData(params.pid, params.load_addr, addr, full_buf) catch {
+    params.adapter.peekData(params.pid, types.Address.from(0), addr, full_buf) catch {
         return error.ReadDataError;
     };
 

--- a/src/linux/dwarf/consts.zig
+++ b/src/linux/dwarf/consts.zig
@@ -474,11 +474,13 @@ pub const Language = enum(u16) {
     // not yet added, pick some random high value
     DW_LANG_Jai = 0xb103,
     DW_LANG_Odin = 0xb104,
+    DW_LANG_C3 = 0xb105,
 
     pub fn fromProducer(producer: []const u8) ?@This() {
         if (mem.startsWith(u8, producer, "zig")) return .DW_LANG_Zig;
         if (mem.startsWith(u8, producer, "odin")) return .DW_LANG_Odin;
         if (mem.containsAtLeast(u8, producer, 1, "Jai")) return .DW_LANG_Jai;
+        if (mem.startsWith(u8, producer, "c3c")) return .DW_LANG_C3;
 
         return null;
     }
@@ -505,6 +507,7 @@ pub const Language = enum(u16) {
             .DW_LANG_Zig => .Zig,
             .DW_LANG_Jai => .Jai,
             .DW_LANG_Odin => .Odin,
+            .DW_LANG_C3 => .C3,
 
             .DW_LANG_nasm => .Assembly,
 

--- a/src/linux/elf.zig
+++ b/src/linux/elf.zig
@@ -707,11 +707,6 @@ test "load ELF files" {
             .path = "./assets/zigloop/out",
             .cu_lang = .DW_LANG_Zig,
         },
-        .{
-            .path = "./assets/c3print/out",
-            .cu_lang = .DW_LANG_C3,
-            .pie = true,
-        },
     });
 
     if (!flags.CI) {

--- a/src/linux/elf.zig
+++ b/src/linux/elf.zig
@@ -707,6 +707,11 @@ test "load ELF files" {
             .path = "./assets/zigloop/out",
             .cu_lang = .DW_LANG_Zig,
         },
+        .{
+            .path = "./assets/c3print/out",
+            .cu_lang = .DW_LANG_C3,
+            .pie = true,
+        },
     });
 
     if (!flags.CI) {

--- a/src/types.zig
+++ b/src/types.zig
@@ -562,6 +562,7 @@ pub const Language = enum(u8) {
     Go,
     Odin,
     Jai,
+    C3,
     Assembly,
 
     pub fn fromPath(fpath: String) @This() {
@@ -583,6 +584,8 @@ pub const Language = enum(u8) {
         if (strings.eql(ext, ".go")) return .Go;
 
         if (strings.eql(ext, ".jai")) return .Jai;
+
+        if (strings.eql(ext, ".c3")) return .C3;
 
         return .Unsupported;
     }
@@ -608,6 +611,7 @@ pub const Language = enum(u8) {
             .{ .path = "/path/to/file.rs", .lang = .Rust },
             .{ .path = "/path/to/file.go", .lang = .Go },
             .{ .path = "/path/to/file.jai", .lang = .Jai },
+            .{ .path = "/path/to/file.c3", .lang = .C3 },
         };
 
         for (cases) |case| try t.expectEqual(case.lang, fromPath(case.path));

--- a/src/types.zig
+++ b/src/types.zig
@@ -568,6 +568,8 @@ pub const Language = enum(u8) {
     pub fn fromPath(fpath: String) @This() {
         const ext = std.fs.path.extension(fpath);
 
+        if (strings.eql(ext, ".c3")) return .C3;
+
         if (strings.eql(ext, ".c")) return .C;
         if (strings.eql(ext, ".h")) return .C;
 
@@ -584,8 +586,6 @@ pub const Language = enum(u8) {
         if (strings.eql(ext, ".go")) return .Go;
 
         if (strings.eql(ext, ".jai")) return .Jai;
-
-        if (strings.eql(ext, ".c3")) return .C3;
 
         return .Unsupported;
     }


### PR DESCRIPTION
Adds support for [C3](https://c3-lang.org/) per user request.

I also noticed that, since c3 compiles binaries as PIE, some data was turning up all zeroes because I was applying the load address when the load address had already been applied. For instance, if we're evaluating a DWARF fbreg opcode and read the address of a variable from a register, the register already has the load addr applied (obviously), so we shouldn't apply it again. Similar stuff happens in `renderVariableValue`.

![image](https://github.com/user-attachments/assets/156e95ae-7f2d-494d-86cd-1e983c06b9e8)
