### PR TITLE
feat(output): scroll output window automatically to show new output

### DIFF
--- a/src/gui/views/Primary.zig
+++ b/src/gui/views/Primary.zig
@@ -238,8 +238,14 @@ pub fn update(self: *Self) State.View {
                 text[ndx] = self.state.subordinate_output.get(ndx);
             }
 
-            // @TODO (jrc): scroll to follow the latest text (can use zui.setScrollYFloat)
             zui.textWrapped("{s}", .{text});
+
+            // (gaweringo): Scroll output down if new text is added
+            // and the scrollbar is currently at the bottom
+            const auto_scroll_threshold = 0.5;
+            if (zui.getScrollMaxY() - zui.getScrollY() <= auto_scroll_threshold) {
+                zui.setScrollHereY(1);
+            }
         }
     }
 

--- a/src/gui/zui/stubs.zig
+++ b/src/gui/zui/stubs.zig
@@ -65,7 +65,13 @@ pub fn setKeyboardFocusHere(_: i32) void {  }
 
 pub fn getMousePos() zui.ImVec2 { return .{}; }
 
+pub fn getScrollY() f32 { return 0; }
+
 pub fn setScrollYFloat(_: f32) void {  }
+
+pub fn getScrollMaxY() f32 { return 0; }
+
+pub fn setScrollHereY(_: f32) void {  }
 
 pub fn beginTable(_: [:0]const u8, _: zui.BeginTable) bool { return true; }
 

--- a/src/gui/zui/zui.zig
+++ b/src/gui/zui/zui.zig
@@ -166,8 +166,20 @@ pub fn getMousePos() zui.ImVec2 {
     return pos;
 }
 
+pub fn getScrollY() f32 {
+    return imgui.igGetScrollY();
+}
+
 pub fn setScrollYFloat(scroll_y: f32) void {
     imgui.igSetScrollY_Float(scroll_y);
+}
+
+pub fn getScrollMaxY() f32 {
+    return imgui.igGetScrollMaxY();
+}
+
+pub fn setScrollHereY(center_y_ratio: f32) void {
+    imgui.igSetScrollHereY(center_y_ratio);
 }
 
 ////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Automatically scrolls the output window to show new output, but only if the scrollbar is already at the bottom of the window.

https://github.com/user-attachments/assets/54743bc3-904e-4e7a-a24c-93f6269ac0b4