### PR TITLE
Parse Go DWARF

### DIFF
--- a/src/debugger/encoding/encoding.zig
+++ b/src/debugger/encoding/encoding.zig
@@ -20,6 +20,7 @@ pub const Params = struct {
     adapter: *Adapter,
     pid: types.PID,
     cu: *const types.CompileUnit,
+    data_types: []const types.DataType,
     target_strings: *strings.Cache,
 
     data_type: *const types.DataType,
@@ -133,7 +134,7 @@ pub fn renderSlice(
         for (params.data_type.form.@"struct".members) |m| {
             const name_str = params.target_strings.get(m.name) orelse continue;
             if (strings.eql(data_name, name_str)) {
-                var base_data_type = params.cu.data_types[m.data_type.int()];
+                var base_data_type = params.data_types[m.data_type.int()];
 
                 // follow pointers and typedefs to their base type
                 var done = false;
@@ -141,12 +142,12 @@ pub fn renderSlice(
                     switch (base_data_type.form) {
                         .pointer => |p| {
                             if (p.data_type) |ptr_type|
-                                base_data_type = params.cu.data_types[ptr_type.int()];
+                                base_data_type = params.data_types[ptr_type.int()];
                         },
 
                         .typedef => |td| {
                             if (td.data_type) |td_type|
-                                base_data_type = params.cu.data_types[td_type.int()];
+                                base_data_type = params.data_types[td_type.int()];
                         },
 
                         else => done = true,
@@ -182,7 +183,7 @@ pub fn renderSlice(
     }
 
     // dereference the pointer (i.e. []u32 -> *u32 -> u32)
-    const ptr_t = params.cu.data_types[ptr.data_type.int()];
+    const ptr_t = params.data_types[ptr.data_type.int()];
     const ptr_data_type = switch (ptr_t.form) {
         .pointer => |p| p.data_type,
         else => return error.InvalidDataType,

--- a/src/file.zig
+++ b/src/file.zig
@@ -142,9 +142,7 @@ test "file hashing and caching" {
 
     const str = "/home/jcalabro/test/file.txt";
 
-    // @TODO (jrc): just use XxHash3 rather than FNV once the self-backend compiler supports it
-    // generated using a 3rd party XxHash3/FNV1A32 implementation
-    const hash_val = 0xebcfc00e;
+    const hash_val = 0xebf9ad2433faf02e;
 
     for (0..100) |_| {
         const h = try cache.add(str);

--- a/src/file.zig
+++ b/src/file.zig
@@ -27,7 +27,7 @@ pub fn hashAbsPath(abs_path: String) Hash {
     const z = trace.zone(@src());
     defer z.end();
 
-    return std.hash.Fnv1a_32.hash(abs_path);
+    return std.hash.Fnv1a_64.hash(abs_path);
 }
 
 pub const SourceFile = struct {

--- a/src/linux/dwarf.zig
+++ b/src/linux/dwarf.zig
@@ -1009,6 +1009,16 @@ fn mapDWARFToTarget(
         }
     }
 
+    {
+        const z1 = trace.zoneN(@src(), "assign function variables");
+        defer z1.end();
+
+        assert(functions.items.len == function_variables.items.len);
+        for (functions.items, 0..) |*f, ndx| {
+            f.variables = try function_variables.items[ndx].toOwnedSlice();
+        }
+    }
+
     return PartiallyReadyCompileUnit{
         .strings = str_cache,
         .delayed_refs = delayed_refs,

--- a/src/linux/dwarf.zig
+++ b/src/linux/dwarf.zig
@@ -528,12 +528,8 @@ pub fn parse(perm_alloc: Allocator, opts: *const ParseOpts, target: *types.Targe
         }
 
         for (data_types.items) |dt| {
-            var dt_copy = try data_types.addOne();
+            var dt_copy = try perm_data_types.addOne();
             try dt_copy.copyFrom(perm_alloc, dt);
-
-            // @TODO (jrc): figure out this bug
-            log.debugf("OK: {s}", .{target.strings.get(dt.name).?});
-            log.flush();
         }
 
         target.data_types = try perm_data_types.toOwnedSlice();

--- a/src/linux/dwarf.zig
+++ b/src/linux/dwarf.zig
@@ -913,10 +913,6 @@ fn mapDWARFToTarget(
                 },
 
                 .DW_TAG_array_type => {
-                    if (opts.die.offset == 0x1a5) {
-                        log.debug("HERE!!!");
-                    }
-
                     if (try optionalAttributeWithForm(&opts, Offset, .DW_AT_type)) |type_offset| {
                         try delayed_refs.array_types.append(cu.opts.scratch, .{
                             .is_global_offset = type_offset.isGlobalOffset(),

--- a/src/linux/dwarf/abbrev.zig
+++ b/src/linux/dwarf/abbrev.zig
@@ -134,7 +134,7 @@ pub const Attr = struct {
             .DW_FORM_ref_addr => {
                 _ = try cu.readInfoOffset();
                 val.form = FormOffset.formType();
-                val.class = .reference;
+                val.class = .global_reference;
             },
             .DW_FORM_ref1 => {
                 _ = try dwarf.read(cu.info_r, u8);
@@ -765,6 +765,12 @@ pub const FormClass = enum(u8) {
     reference,
     string,
     stroffsetptr,
+
+    /// @NOTE (jrc): This is not a real class in the DWARF spec. I added it to differentiate
+    /// between `DW_FORM_ref_addr` and `DW_FORM_ref*`, which is needed when determining if an
+    /// offset is global (from the start of the `.debug_info` section), or local (from the start
+    /// of the compile unit DIE).
+    global_reference,
 
     pub fn contents(self: @This(), cu: *const info.CompileUnit, offset: Offset) error{InvalidDWARFInfo}![]const u8 {
         const buf = switch (self) {

--- a/src/linux/elf.zig
+++ b/src/linux/elf.zig
@@ -675,6 +675,10 @@ test "load ELF files" {
             .cu_lang = .DW_LANG_C11,
         },
         .{
+            .path = "./assets/cinline/out",
+            .cu_lang = .DW_LANG_C11,
+        },
+        .{
             // should follow symlinks
             .path = "./assets/test_files/symlink_linux_x86-64_cloop_out",
             .cu_lang = .DW_LANG_C11,
@@ -695,18 +699,22 @@ test "load ELF files" {
             .path = "./assets/cprint/out",
             .cu_lang = .DW_LANG_C11,
         },
-        // .{
-        //     .path = "./assets/goloop/out",
-        //     .cu_lang = .DW_LANG_Go,
-        // },
-        // .{
-        //     .path = "./assets/rustloop/out",
-        //     .pie = true,
-        //     .cu_lang = .DW_LANG_Rust,
-        // },
+        .{
+            .path = "./assets/goloop/out",
+            .cu_lang = .DW_LANG_Go,
+        },
+        .{
+            .path = "./assets/rustloop/out",
+            .pie = true,
+            .cu_lang = .DW_LANG_Rust,
+        },
         .{
             .path = "./assets/zigloop/out",
             .cu_lang = .DW_LANG_Zig,
+        },
+        .{
+            .path = "./assets/odinloop/out",
+            .cu_lang = .DW_LANG_Odin,
         },
     });
 
@@ -716,19 +724,6 @@ test "load ELF files" {
         try cases.append(.{
             .path = "./assets/jailoop/out",
             .cu_lang = .DW_LANG_Jai,
-        });
-
-        // @TODO (jrc): fix cinline in CI (it works locally)
-        try cases.append(.{
-            .path = "./assets/cinline/out",
-            .cu_lang = .DW_LANG_C11,
-        });
-
-        // There appears to be a bug in odin related to libedit
-        // https://github.com/odin-lang/Odin/issues/2271
-        try cases.append(.{
-            .path = "./assets/odinloop/out",
-            .cu_lang = .DW_LANG_Odin,
         });
     }
 

--- a/src/linux/elf.zig
+++ b/src/linux/elf.zig
@@ -316,6 +316,7 @@ pub fn load(opts: *const LoadOpts) LoadError!*types.Target {
         .addr_size = .four,
         .unwinder = undefined,
         .compile_units = undefined,
+        .data_types = undefined,
         .strings = try strings.Cache.init(opts.perm),
     };
 
@@ -787,7 +788,6 @@ fn findCompileUnitCopyAllocationFailures(alloc: Allocator, cu: types.CompileUnit
     alloc.free(dst.ranges);
     for (dst.sources) |s| alloc.free(s.statements);
     alloc.free(dst.sources);
-    alloc.free(dst.data_types);
     alloc.free(dst.variables);
     for (dst.functions.functions) |f| f.deinit(alloc);
     alloc.free(dst.functions.functions);

--- a/src/linux/elf.zig
+++ b/src/linux/elf.zig
@@ -704,11 +704,6 @@ test "load ELF files" {
             .cu_lang = .DW_LANG_Go,
         },
         .{
-            .path = "./assets/rustloop/out",
-            .pie = true,
-            .cu_lang = .DW_LANG_Rust,
-        },
-        .{
             .path = "./assets/zigloop/out",
             .cu_lang = .DW_LANG_Zig,
         },
@@ -719,11 +714,18 @@ test "load ELF files" {
     });
 
     if (!flags.CI) {
-        // @NOTE (jrc): we test jai in local builds while the
-        // compiler it still in beta
+        // @NOTE (jrc): we test jai in local builds while the compiler it still in beta
         try cases.append(.{
             .path = "./assets/jailoop/out",
             .cu_lang = .DW_LANG_Jai,
+        });
+
+        // @NOTE (jrc): there's an issue loading rustloop on the CI boxes, but it works locally.
+        // Rust isn't supported yet, so leaving this out of CI.
+        try cases.append(.{
+            .path = "./assets/rustloop/out",
+            .pie = true,
+            .cu_lang = .DW_LANG_Rust,
         });
     }
 

--- a/src/strings.zig
+++ b/src/strings.zig
@@ -32,7 +32,7 @@ pub fn hash(str: String) Hash {
     const z = trace.zone(@src());
     defer z.end();
 
-    return std.hash.Fnv1a_32.hash(str);
+    return std.hash.Fnv1a_64.hash(str);
 }
 
 /// A simple data structure used to do string interning

--- a/src/types.zig
+++ b/src/types.zig
@@ -415,7 +415,6 @@ pub const CompileUnit = struct {
             .address_size = src.address_size,
             .ranges = ranges,
             .sources = try sources.toOwnedSlice(alloc),
-            // .data_types = try data_types.toOwnedSlice(alloc),
             .variables = variables,
             .functions = .{
                 .functions = try functions.toOwnedSlice(alloc),

--- a/src/types.zig
+++ b/src/types.zig
@@ -242,6 +242,9 @@ pub const Target = struct {
     /// information on disk
     compile_units: []const CompileUnit,
 
+    /// The full list of all known data types in the program
+    data_types: []const DataType,
+
     /// Finds and returns a pointer to the CompileUnit that contains the given address. This function
     /// does not have knowledge of the subordinate's load address for PIE binaries.
     pub fn compileUnitForAddr(self: Self, addr: Address) ?CompileUnit {
@@ -343,14 +346,11 @@ pub const CompileUnit = struct {
     /// The list of the source files that were used in this compile unit
     sources: []const SourceFile,
 
-    /// The list of all data types declared within this compile unit
-    data_types: []const DataType,
-
     /// The list of functions and their address ranges in this compile unit
     functions: Functions,
 
     /// All variables declared at any point in this compile unit
-    variables: []const Variable,
+    variables: []Variable,
 
     /// Returns true if there is an address range in this compile unit that contains `addr`
     pub fn containsAddress(self: Self, addr: Address) bool {
@@ -374,30 +374,6 @@ pub const CompileUnit = struct {
             .file_hash = s.file_hash,
             .statements = try safe.copySlice(SourceStatement, alloc, s.statements),
         });
-
-        var data_types = ArrayListUnmanaged(DataType){};
-        errdefer {
-            for (data_types.items) |dt| {
-                switch (dt.form) {
-                    .@"struct" => |s| alloc.free(s.members),
-                    .@"union" => |u| alloc.free(u.members),
-                    .@"enum" => |e| alloc.free(e.values),
-                    else => {},
-                }
-            }
-            data_types.deinit(alloc);
-        }
-        for (src.data_types) |src_dt| {
-            var copy_dt = src_dt;
-            switch (src_dt.form) {
-                .@"struct" => |s| copy_dt.form.@"struct".members = try safe.copySlice(MemberType, alloc, s.members),
-                .@"union" => |u| copy_dt.form.@"union".members = try safe.copySlice(MemberType, alloc, u.members),
-                .@"enum" => |e| copy_dt.form.@"enum".values = try safe.copySlice(EnumValue, alloc, e.values),
-                else => {},
-            }
-            try data_types.append(alloc, copy_dt);
-        }
-        // const data_types = try safe.copySlice(DataType, alloc, src.data_types);
 
         const variables = try safe.copySlice(Variable, alloc, src.variables);
         errdefer alloc.free(variables);
@@ -439,7 +415,7 @@ pub const CompileUnit = struct {
             .address_size = src.address_size,
             .ranges = ranges,
             .sources = try sources.toOwnedSlice(alloc),
-            .data_types = try data_types.toOwnedSlice(alloc),
+            // .data_types = try data_types.toOwnedSlice(alloc),
             .variables = variables,
             .functions = .{
                 .functions = try functions.toOwnedSlice(alloc),
@@ -665,6 +641,8 @@ pub const Function = struct {
 
 /// A type declaration within a CompileUnit
 pub const DataType = struct {
+    const Self = @This();
+
     /// The number of bytes required to store a variable of this type
     size_bytes: u64,
 
@@ -673,6 +651,25 @@ pub const DataType = struct {
 
     /// The form of the variable (primitive, array, struct, etc.)
     form: DataTypeForm,
+
+    pub fn deinit(self: Self, alloc: Allocator) void {
+        switch (self.form) {
+            .@"struct" => |s| alloc.free(s.members),
+            .@"union" => |u| alloc.free(u.members),
+            .@"enum" => |e| alloc.free(e.values),
+            else => {},
+        }
+    }
+
+    pub fn copyFrom(dst: *Self, alloc: Allocator, src: Self) Allocator.Error!void {
+        dst.* = src;
+        switch (src.form) {
+            .@"struct" => |s| dst.form.@"struct".members = try safe.copySlice(MemberType, alloc, s.members),
+            .@"union" => |u| dst.form.@"union".members = try safe.copySlice(MemberType, alloc, u.members),
+            .@"enum" => |e| dst.form.@"enum".values = try safe.copySlice(EnumValue, alloc, e.values),
+            else => {},
+        }
+    }
 };
 
 /// One of the many forms a variable could take


### PR DESCRIPTION
This is step one of many towards getting Go support working: parsing Go DWARF.

Previously, we used a multi-threaded Go parser to load each individual compile unit across N threads. This seemed like a good idea at the time, but unfortunately, Go uses global offsets (GOFF in dwarfdump) that are offsets from the start of the `.debug_info` section, as opposed to every other compiler I've tested which does local offsets from the start of the DIE's containing compile unit DIE.

Because we need to handle global offsets, parsing compile unit DIEs and mapping their type references is no longer an embarrassingly parallel problem, and it no longer makes sense to have a model where each CU is parsed by a worker thread.

It didn't really even make all that much sense to do it in the first place because what tends to happen in most real-world projects is that there are many small CUs, then just a few very large ones. So the speedup sometimes is noticeable, but in my testing, usually it's not. Now, parsing Ghostty's debug info is about 2x as slow for instance on this beefy 32 thread machine. So it's not like we were getting a 32x speedup to start with.

Anyhow, the test Go binaries **parse without error**. There still are several go-specific DWARF attributes to handle (i.e. `DW_AT_go_runtime_type`), but I'm going to implement those later.

Additionally, we have to do some extra work to make sure that Go's green threads models steps correctly on the goroutine the user expects.

One other item of note: because types are now considered global, the `data_types` array has moved from `CompileUnit` to `Target`. This was a relatively small change since all types are just indexed with `usize`'s already.

Here's a dead-simple screenshot of it working. Note that stepping is very janky, and no locals are detected properly, but it is a start.

![image](https://github.com/user-attachments/assets/c5b549d6-b525-48c9-8109-627748c68728)